### PR TITLE
Add desktop extension support

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,23 @@
+{
+  "dxt_version": "0.1.0",
+  "name": "Netlify MCP",
+  "version": "1.9.12",
+  "description": "MCP server for Netlify API interactions, deployments, and project management",
+  "author": {
+    "name": "Netlify",
+    "email": "support@netlify.com"
+  },
+  "server": {
+    "type": "node",
+    "entry_point": "dist/netlify-mcp.js",
+    "mcp_config": {
+      "server_name": "netlify-mcp",
+      "server_version": "1.9.12",
+      "command": "node"
+    }
+  },
+  "build": {
+    "include": ["dist/**/*", "package.json"],
+    "exclude": ["node_modules/**/*", "src/**/*", "*.ts"]
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@netlify/mcp",
-  "version": "1.9.2",
+  "version": "1.9.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@netlify/mcp",
-      "version": "1.9.2",
+      "version": "1.9.12",
       "license": "ISC",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",


### PR DESCRIPTION
## Summary
• Added manifest.json configuration for Claude Desktop extension installation
• Updated package-lock.json to reflect current version (1.9.12)
• Successfully tested extension packaging with Anthropic DXT tooling

## Test plan
- [x] Created manifest.json with required desktop extension schema
- [x] Verified server entry point configuration (dist/netlify-mcp.js)
- [x] Tested extension packaging with `npx @anthropic-ai/dxt pack`
- [x] Confirmed .dxt file generation for drag-and-drop installation
- [ ] Test installation in Claude Desktop application
- [ ] Verify MCP server functionality after desktop extension installation

🤖 Generated with [Claude Code](https://claude.ai/code)