### PR TITLE
fix: add npm package metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,14 @@
   "bin": {
     "netlify-mcp": "./dist/netlify-mcp.js"
   },
+  "homepage": "https://docs.netlify.com/welcome/build-with-ai/netlify-mcp-server/",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/netlify/netlify-mcp.git"
+  },
+  "bugs": {
+    "url": "https://github.com/netlify/netlify-mcp/issues"
+  },
   "scripts": {
     "build": "tsup ./netlify-mcp.ts --format esm",
     "start": "node ./dist/netlify-mcp.js",


### PR DESCRIPTION
## Summary
- Add homepage, repository, and bugs metadata for the @netlify/mcp npm package.
- Point the homepage to the official Netlify MCP docs and the issue tracker to this repository.

## Validation
- Metadata smoke check for homepage/repository/bugs fields
- npm pack --dry-run --ignore-scripts .
- git diff --check