### PR TITLE
Add server icon and website metadata to serverInfo

### DIFF
--- a/netlify/functions/mcp.ts
+++ b/netlify/functions/mcp.ts
@@ -142,7 +142,10 @@ async function handleMCPPost(req: Request) {
 
   const server = new McpServer({
     name: "netlify",
+    title: "Netlify",
     version: getPackageVersion(),
+    websiteUrl: "https://www.netlify.com",
+    icons: [{ src: "https://www.netlify.com/favicon/icon.svg", mimeType: "image/svg+xml" }],
   });
 
   const contextConsumer = await getContextConsumerConfig();


### PR DESCRIPTION
MCP clients that list connectors (e.g. Claude Design's "Send to..." menu) render the server icon from `serverInfo.icons`. We only set `name` and `version`, so the Netlify entry shows up with no logo.

This adds `title`, `websiteUrl`, and an `icons` entry pointing at https://www.netlify.com/favicon/icon.svg (returns 200, `image/svg+xml`). The installed MCP SDK (^1.29.0) already supports these fields.

Verified: tsc clean, 13/13 tests pass, tsup build succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)