### PR TITLE
spike: trial MCP SDK v2 (2026-07-28) transport migration

### DIFF
--- a/SPIKE_FINDINGS.md
+++ b/SPIKE_FINDINGS.md
@@ -1,0 +1,43 @@
+# Spike: MCP TypeScript SDK v2 (2026-07-28 protocol support)
+
+Branch: `spike/mcp-sdk-v2` — **do not merge as-is** (beta SDK, partial migration).
+Base: `main` @ `aa39e8d` (all the structured-logging work).
+
+## Goal
+Confirm the Netlify MCP can support the new `2026-07-28` protocol (the RC that
+triggered `Unsupported protocol version` on our v1 SDK) **and** keep serving
+2025-era clients, by trialing the v2 SDK beta.
+
+## What was done
+- Added `@modelcontextprotocol/server@2.0.0-beta.4` + `@modelcontextprotocol/core@2.0.0-beta.4` (exact pins). Kept `@modelcontextprotocol/sdk@^1.29.0` (CLI + tools still use it).
+- Migrated `netlify/functions/mcp.ts` from v1 (`McpServer` + `StreamableHTTPServerTransport` + `fetch-to-node`) to v2 `createMcpHandler` + web-standard `.fetch`.
+- Kept all our custom wiring intact: structured logging + request context, the pre-handler auth gate (`userIsAuthenticated` → `returnNeedsAuthResponse`), identity enrichment, CORS, the `UNAUTHED_ERROR_PREFIX` re-check.
+
+## Proven (smoke-tested against the v2 handler)
+- **Legacy `2025-11-25`**: `initialize` and `tools/list` → `200`, correct results.
+- **Modern `2026-07-28`**: with the required per-request `_meta` envelope → `200`, tool list returned (new modern fields `resultType`/`ttlMs`/`cacheScope`). Crucially, `2026-07-28` is **recognized**, not the `Unsupported protocol version` 400 we get on v1.
+- **One `createMcpHandler` serves both eras** (default `legacy: 'stateless'`).
+- Web-standard `(Request) => Response` fits Netlify Functions directly — `fetch-to-node` bridge removed.
+- `tsc --noEmit` clean.
+
+## The blocker for a full migration: zod v3 → v4
+- v2 SDK depends on **`zod@^4.2.0`**; this project is on **`zod@3.25.76`** (v3).
+- v2's `registerTool` types `inputSchema` against zod v4. Registering a zod v3
+  schema fails typecheck (`ZodEnum … missing toJSONSchema/encode/decode/…`).
+- So in this spike `get-netlify-coding-context` is registered **without** an
+  input schema, and `bindTools` + the Claude design-import tool are **not wired
+  yet** (they build zod v3 schemas).
+
+## Remaining work for a real migration
+1. **Upgrade the project to zod v4** (breaking; touches every tool's schema). This is the bulk of the effort.
+2. **Migrate `bindTools`** (`src/tools/index.ts`) and all domain tools to the v2 `registerTool` + zod v4 API. The `npx @modelcontextprotocol/codemod@beta v1-to-v2 .` codemod automates much of the `.tool()`→`registerTool()` renames.
+3. **Re-wire the Claude design-import tool** (`registerClaudeDesignImportTool`).
+4. **client-detection**: 2026-07-28 puts `clientInfo` in per-request `_meta` (keys `io.modelcontextprotocol/clientInfo` etc.), not the initialize handshake — update `client-detection.ts` and our `clientInfoName/Version` logging to read `_meta`.
+5. **CLI (`netlify-mcp.ts`)**: still v1 stdio; migrate to `@modelcontextprotocol/server/stdio` (`serveStdio`) when ready.
+6. **Verify on the real Netlify Functions runtime** (not just local smoke) and test a real 2026-07-28 client + a 2025 client end-to-end through auth.
+7. Watch for the **stable v2 release** (lands with the spec on 2026-07-28) and re-pin off `-beta.4`.
+
+## Recommendation
+The architecture is compatible and the transport migration is clean. The gating
+work is the **zod v4 upgrade**; everything else is mechanical. Keep `main` on v1
+(production) until the stable v2 SDK ships, then land the full migration.

--- a/SPIKE_FINDINGS.md
+++ b/SPIKE_FINDINGS.md
@@ -1,43 +1,28 @@
-# Spike: MCP TypeScript SDK v2 (2026-07-28 protocol support)
+# MCP TypeScript SDK v2 migration (2026-07-28 protocol support)
 
-Branch: `spike/mcp-sdk-v2` — **do not merge as-is** (beta SDK, partial migration).
-Base: `main` @ `aa39e8d` (all the structured-logging work).
+Branch: `spike/mcp-sdk-v2`. Base: `main` (structured-logging work).
+Status: **full migration complete & typecheck/test-clean** on the beta SDK. Still beta — verify on a real deploy and re-pin at GA before merging.
 
-## Goal
-Confirm the Netlify MCP can support the new `2026-07-28` protocol (the RC that
-triggered `Unsupported protocol version` on our v1 SDK) **and** keep serving
-2025-era clients, by trialing the v2 SDK beta.
+## Done
+- Upgraded the project to **zod v4** (`zod@^4.2.0`, resolves to 4.4.3; deduped with the SDK's zod).
+- Removed **v1** `@modelcontextprotocol/sdk`; added **v2** `@modelcontextprotocol/server` + `@modelcontextprotocol/core` (`2.0.0-beta.4`, exact-pinned).
+- `netlify/functions/mcp.ts`: v1 transport + `fetch-to-node` → **v2 `createMcpHandler`** (web-standard `.fetch`). Per-request factory registers the **full toolset**: `get-netlify-coding-context` (schema restored), the Claude design-import tool, and all domain tools via `bindTools`.
+- `src/tools/index.ts`, `src/tools/types.ts`, `src/tools/design-import/import-claude-design.ts`: `McpServer`/`ToolAnnotations` re-sourced from `@modelcontextprotocol/server`. The 24 domain-tool schema files needed **no changes** (their zod usage is v3/v4-compatible).
+- `netlify-mcp.ts` (CLI): v1 `StdioServerTransport` → **v2 `serveStdio`**.
+- Added `mcp server built` (era, verboseMode, domainToolsRegistered) + `tools list requested` logging.
 
-## What was done
-- Added `@modelcontextprotocol/server@2.0.0-beta.4` + `@modelcontextprotocol/core@2.0.0-beta.4` (exact pins). Kept `@modelcontextprotocol/sdk@^1.29.0` (CLI + tools still use it).
-- Migrated `netlify/functions/mcp.ts` from v1 (`McpServer` + `StreamableHTTPServerTransport` + `fetch-to-node`) to v2 `createMcpHandler` + web-standard `.fetch`.
-- Kept all our custom wiring intact: structured logging + request context, the pre-handler auth gate (`userIsAuthenticated` → `returnNeedsAuthResponse`), identity enrichment, CORS, the `UNAUTHED_ERROR_PREFIX` re-check.
+## Verified
+- `tsc --noEmit` clean; `npm test` 31/31.
+- One `createMcpHandler` serves **both** `2026-07-28` (modern, with `_meta` envelope) and `2025-11-25` (legacy) → both `200`. The original `Unsupported protocol version` error is gone.
+- zod v4 union/object schemas (the `bindTools` selector pattern) register and serialize into `tools/list` at runtime.
 
-## Proven (smoke-tested against the v2 handler)
-- **Legacy `2025-11-25`**: `initialize` and `tools/list` → `200`, correct results.
-- **Modern `2026-07-28`**: with the required per-request `_meta` envelope → `200`, tool list returned (new modern fields `resultType`/`ttlMs`/`cacheScope`). Crucially, `2026-07-28` is **recognized**, not the `Unsupported protocol version` 400 we get on v1.
-- **One `createMcpHandler` serves both eras** (default `legacy: 'stateless'`).
-- Web-standard `(Request) => Response` fits Netlify Functions directly — `fetch-to-node` bridge removed.
-- `tsc --noEmit` clean.
+## Remaining before merge
+1. **Deploy to a real Netlify environment** and test a live `2026-07-28` client + a `2025` client end-to-end through OAuth (local smoke only so far).
+2. **`_meta` client info**: `2026-07-28` moves `clientInfo` into per-request `_meta` (keys `io.modelcontextprotocol/clientInfo` etc.), not the initialize body. Update `client-detection.ts` (design-import gating) and the `clientInfoName`/`clientInfoVersion` logging to read `_meta` — today they fall back to user-agent for modern clients.
+3. **Re-pin off `-beta.4`** to GA `2.0.0` when it ships (with the spec, 2026-07-28).
+4. Optional: hoist `createMcpHandler` to module scope (currently per-request) using `ctx.requestInfo`, once the `_meta` path removes the need to close over the parsed body.
+5. Remove now-unused `fetch-to-node` dependency.
 
-## The blocker for a full migration: zod v3 → v4
-- v2 SDK depends on **`zod@^4.2.0`**; this project is on **`zod@3.25.76`** (v3).
-- v2's `registerTool` types `inputSchema` against zod v4. Registering a zod v3
-  schema fails typecheck (`ZodEnum … missing toJSONSchema/encode/decode/…`).
-- So in this spike `get-netlify-coding-context` is registered **without** an
-  input schema, and `bindTools` + the Claude design-import tool are **not wired
-  yet** (they build zod v3 schemas).
-
-## Remaining work for a real migration
-1. **Upgrade the project to zod v4** (breaking; touches every tool's schema). This is the bulk of the effort.
-2. **Migrate `bindTools`** (`src/tools/index.ts`) and all domain tools to the v2 `registerTool` + zod v4 API. The `npx @modelcontextprotocol/codemod@beta v1-to-v2 .` codemod automates much of the `.tool()`→`registerTool()` renames.
-3. **Re-wire the Claude design-import tool** (`registerClaudeDesignImportTool`).
-4. **client-detection**: 2026-07-28 puts `clientInfo` in per-request `_meta` (keys `io.modelcontextprotocol/clientInfo` etc.), not the initialize handshake — update `client-detection.ts` and our `clientInfoName/Version` logging to read `_meta`.
-5. **CLI (`netlify-mcp.ts`)**: still v1 stdio; migrate to `@modelcontextprotocol/server/stdio` (`serveStdio`) when ready.
-6. **Verify on the real Netlify Functions runtime** (not just local smoke) and test a real 2026-07-28 client + a 2025 client end-to-end through auth.
-7. Watch for the **stable v2 release** (lands with the spec on 2026-07-28) and re-pin off `-beta.4`.
-
-## Recommendation
-The architecture is compatible and the transport migration is clean. The gating
-work is the **zod v4 upgrade**; everything else is mechanical. Keep `main` on v1
-(production) until the stable v2 SDK ships, then land the full migration.
+## Notes
+- `oauth-server.ts` and the edge `proxy.ts`/`request-logger.ts` were untouched — they don't use the MCP transport SDK.
+- Handler is built per request (closes over the parsed body for client-detection + token access), matching v1 behavior; fine for a stateless function.

--- a/netlify-mcp.ts
+++ b/netlify-mcp.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { McpServer } from "@modelcontextprotocol/server";
+import { serveStdio } from "@modelcontextprotocol/server/stdio";
 import { z } from "zod";
 import { getContextConsumerConfig, getNetlifyCodingContext } from "./src/context/coding-context.ts";
 import { getPackageVersion } from "./src/utils/version.ts";
@@ -68,44 +68,46 @@ if(process.argv.includes('--proxy-path') && proxyPath) {
   // Verbose mode is for systems that can't support complex tool schemas using unions/anyOf
   const verboseMode = process.argv.includes('--verbose');
 
-  const server = new McpServer({
-    name: "netlify-mcp",
-    version: getPackageVersion()
-  });
+  // v2 stdio serving: the factory builds a fresh server per connection.
+  serveStdio(async () => {
+    const server = new McpServer({
+      name: "netlify-mcp",
+      version: getPackageVersion()
+    });
 
-  // load the consumer configuration for the MCP so
-  // we can share all of the available context for the
-  // client to select from.
-  const contextConsumer = await getContextConsumerConfig();
-  const availableContextTypes = Object.keys(contextConsumer?.contextScopes || {});
-  const creationTypeEnum = z.enum(availableContextTypes as [string, ...string[]]);
-  server.registerTool(
-    "netlify-coding-rules",
-    {
-      description: "ALWAYS call when writing serverless or Netlify code. required step before creating or editing any type of functions, Netlify sdk/library  usage, etc.",
-      inputSchema:{
-        creationType: creationTypeEnum
+    // load the consumer configuration for the MCP so
+    // we can share all of the available context for the
+    // client to select from.
+    const contextConsumer = await getContextConsumerConfig();
+    const availableContextTypes = Object.keys(contextConsumer?.contextScopes || {});
+    const creationTypeEnum = z.enum(availableContextTypes as [string, ...string[]]);
+    server.registerTool(
+      "netlify-coding-rules",
+      {
+        description: "ALWAYS call when writing serverless or Netlify code. required step before creating or editing any type of functions, Netlify sdk/library  usage, etc.",
+        inputSchema:{
+          creationType: creationTypeEnum
+        },
+        annotations: {
+          readOnlyHint: true
+        }
       },
-      annotations: {
-        readOnlyHint: true
+      async ({creationType}) => {
+
+        checkCompatibility();
+
+        const context = await getNetlifyCodingContext(creationType);
+        const text = context?.content || '';
+
+        return ({
+          content: [{type: "text" as const, text}]
+        });
       }
-    },
-    async ({creationType}: {creationType: z.infer<typeof creationTypeEnum>}) => {
+    );
 
-      checkCompatibility();
+    await bindTools(server, undefined, verboseMode);
 
-      const context = await getNetlifyCodingContext(creationType);
-      const text = context?.content || '';
-
-      return ({
-        content: [{type: "text", text}]
-      });
-    }
-  );
-
-  await bindTools(server, undefined, verboseMode);
-
-  const transport = new StdioServerTransport();
-  await server.connect(transport);
+    return server;
+  });
 
 }

--- a/netlify/functions/mcp.ts
+++ b/netlify/functions/mcp.ts
@@ -29,11 +29,12 @@ initLogger({ forward: systemLogForwarder });
 // protocol revisions. Auth is pass-through — we gate in front and the tools
 // read the token from the request themselves (unchanged from v1).
 const mcpHandler = createMcpHandler(
-  async () => {
+  async (ctx) => {
     const server = new McpServer({
       name: "netlify",
       version: getPackageVersion(),
     });
+    const registeredTools: string[] = [];
 
     const contextConsumer = await getContextConsumerConfig();
     const availableContextTypes = Object.keys(contextConsumer?.contextScopes || {});
@@ -56,12 +57,26 @@ const mcpHandler = createMcpHandler(
         return { content: [{ type: "text" as const, text: context?.content || "" }] };
       },
     );
+    registeredTools.push("get-netlify-coding-context");
 
     // SPIKE TODO: register the domain tools + Claude design-import here once
     // their zod v3 schemas are migrated to zod/v4 (v2's registerTool types
     // inputSchema against zod/v4). Today `bindTools(server, req, verboseMode)`
     // and `registerClaudeDesignImportTool(server, req)` would not type-check
     // against the v2 McpServer.
+
+    // Visibility in the function logs: which protocol era this request is served
+    // as, and EXACTLY which tools are exposed. On this spike branch only the
+    // coding-context tool is registered — the domain tools (bindTools) and
+    // design-import are deferred pending the zod v4 migration, which is why
+    // clients currently see nothing else. This makes that explicit per request.
+    log.info('mcp server built', {
+      era: ctx.era,
+      toolCount: registeredTools.length,
+      tools: registeredTools,
+      domainToolsRegistered: false,
+    });
+
     return server;
   },
   { onerror: (error: Error) => log.error("mcp handler error", { err: error }) },
@@ -202,6 +217,10 @@ async function handleMCPPost(req: Request) {
   if (body?.method === 'tools/call') {
     addLogContext({ toolName: body?.params?.name });
     log.info('tool call', paramsSummary(body?.params));
+  } else if (body?.method === 'tools/list') {
+    // Tool discovery — pair this with the 'mcp server built' line (which reports
+    // toolCount/tools) to see exactly what a client is offered.
+    log.info('tools list requested');
   }
 
   // Reconstruct a request with the buffered body so the v2 handler can read it

--- a/netlify/functions/mcp.ts
+++ b/netlify/functions/mcp.ts
@@ -1,20 +1,17 @@
-// SPIKE: migrated to the MCP TypeScript SDK v2 (@modelcontextprotocol/server,
-// 2.0.0-beta.4) to support the 2026-07-28 protocol. v2's createMcpHandler serves
-// BOTH 2026-07-28 (modern) and 2025-era (legacy) traffic from one web-standard
-// (Request)=>Response handler — replacing v1's StreamableHTTPServerTransport +
-// fetch-to-node bridge.
-//
-// DEFERRED (not in this spike): bindTools (all domain tools) and the Claude
-// design-import tool. Those register schemas built with zod v3, but v2's
-// registerTool types against `zod/v4`. Migrating them is the remaining lift —
-// see SPIKE note below. Only get-netlify-coding-context is wired here to prove
-// the transport + dual-era serving end to end.
+// Netlify MCP server on the MCP TypeScript SDK v2 (@modelcontextprotocol/server).
+// createMcpHandler serves BOTH 2026-07-28 (modern) and 2025-era (legacy) traffic
+// from one web-standard (Request)=>Response handler — replacing v1's
+// StreamableHTTPServerTransport + fetch-to-node bridge.
 import { createMcpHandler, McpServer } from "@modelcontextprotocol/server";
+import { z } from "zod";
 import { addCORSHeadersToFetchResp, returnNeedsAuthResponse } from "./mcp-server/utils.ts";
 import { getContextConsumerConfig, getNetlifyCodingContext } from "../../src/context/coding-context.ts";
 import { getPackageVersion } from "../../src/utils/version.ts";
 import { checkCompatibility } from "../../src/utils/compatibility.ts";
+import { bindTools } from "../../src/tools/index.ts";
+import { registerClaudeDesignImportTool } from "../../src/tools/design-import/import-claude-design.ts";
 import { userIsAuthenticated, getTokenIdentity, UNAUTHED_ERROR_PREFIX } from "../../src/utils/api-networking.ts";
+import { isClaudeMCPClient } from "../../src/utils/client-detection.ts";
 import { maskToken, paramsSummary } from "./mcp-server/logging.ts";
 import { log, withLogContext, addLogContext, newRequestId, initLogger, getDeployId } from "./mcp-server/logger.ts";
 import { systemLogForwarder } from "./mcp-server/system-log-forwarder.ts";
@@ -23,64 +20,6 @@ import {Config, Context} from "@netlify/functions";
 // Route structured logs onto Netlify's system-log channel for this Node
 // function. Runs once at cold start; edge/CLI keep the default console forwarder.
 initLogger({ forward: systemLogForwarder });
-
-// The v2 handler is created once. Its factory runs per request and returns a
-// fresh McpServer; `era` (legacy|modern) lets the same handler serve both
-// protocol revisions. Auth is pass-through — we gate in front and the tools
-// read the token from the request themselves (unchanged from v1).
-const mcpHandler = createMcpHandler(
-  async (ctx) => {
-    const server = new McpServer({
-      name: "netlify",
-      version: getPackageVersion(),
-    });
-    const registeredTools: string[] = [];
-
-    const contextConsumer = await getContextConsumerConfig();
-    const availableContextTypes = Object.keys(contextConsumer?.contextScopes || {});
-
-    // SPIKE: registered WITHOUT an inputSchema. The real tool takes a
-    // `creationType` enum built with zod v3, but v2's registerTool types
-    // inputSchema against zod v4 (the SDK depends on zod@^4.2.0; the project is
-    // on zod@3.25.76). Proving the transport here; the schema'd registration
-    // returns once the project moves to zod v4 (same lift as bindTools).
-    server.registerTool(
-      "get-netlify-coding-context",
-      {
-        description:
-          "ALWAYS call when writing code. Required step before creating or editing any type of functions, Netlify sdk/library usage, etc. Use other operations for project management.",
-        annotations: { readOnlyHint: true },
-      },
-      async () => {
-        checkCompatibility();
-        const context = await getNetlifyCodingContext(availableContextTypes[0]);
-        return { content: [{ type: "text" as const, text: context?.content || "" }] };
-      },
-    );
-    registeredTools.push("get-netlify-coding-context");
-
-    // SPIKE TODO: register the domain tools + Claude design-import here once
-    // their zod v3 schemas are migrated to zod/v4 (v2's registerTool types
-    // inputSchema against zod/v4). Today `bindTools(server, req, verboseMode)`
-    // and `registerClaudeDesignImportTool(server, req)` would not type-check
-    // against the v2 McpServer.
-
-    // Visibility in the function logs: which protocol era this request is served
-    // as, and EXACTLY which tools are exposed. On this spike branch only the
-    // coding-context tool is registered — the domain tools (bindTools) and
-    // design-import are deferred pending the zod v4 migration, which is why
-    // clients currently see nothing else. This makes that explicit per request.
-    log.info('mcp server built', {
-      era: ctx.era,
-      toolCount: registeredTools.length,
-      tools: registeredTools,
-      domainToolsRegistered: false,
-    });
-
-    return server;
-  },
-  { onerror: (error: Error) => log.error("mcp handler error", { err: error }) },
-);
 
 // Netlify serverless function handler
 export default async (req: Request, context: Context) => {
@@ -105,7 +44,6 @@ export default async (req: Request, context: Context) => {
 
         log.debug('mcp request', { auth: maskToken(req.headers.get('Authorization')) });
 
-        // Handle different HTTP methods
         if (req.method === "POST") {
           return await handleMCPPost(req);
         } else if (req.method === "GET") {
@@ -131,16 +69,10 @@ export default async (req: Request, context: Context) => {
         return new Response(
           JSON.stringify({
             jsonrpc: "2.0",
-            error: {
-              code: -32603,
-              message: "Internal server error",
-            },
+            error: { code: -32603, message: "Internal server error" },
             id: null,
           }),
-          {
-            status: 500,
-            headers: { "Content-Type": "application/json" }
-          }
+          { status: 500, headers: { "Content-Type": "application/json" } }
         );
       }
     }
@@ -150,13 +82,11 @@ export default async (req: Request, context: Context) => {
 
 async function handleMCPPost(req: Request) {
 
-  // Read the body once as text so we can tell an empty body (common for
-  // probes/health-checks/scanners hitting the public endpoint) apart from
-  // malformed/truncated JSON (which may signal a real client or proxy issue).
+  // Read the body once as text so we can tell an empty body (probes/scanners)
+  // apart from malformed/truncated JSON.
   const raw = await req.text();
 
   if (!raw.trim()) {
-    // Empty POST — not a real MCP request. Respond without logging noise.
     return jsonRpcError(400, -32600, 'Request body is required');
   }
 
@@ -172,7 +102,7 @@ async function handleMCPPost(req: Request) {
   }
 
   // Fold the MCP call identity into the request context so every subsequent line
-  // (auth, tool binding, response) is attributed to this JSON-RPC call.
+  // is attributed to this JSON-RPC call.
   addLogContext({
     mcpMethod: body?.method,
     mcpId: body?.id,
@@ -180,8 +110,7 @@ async function handleMCPPost(req: Request) {
     clientInfoVersion: body?.params?.clientInfo?.version,
   });
 
-  // Log the SHAPE of the call only — the tool name and the names of the
-  // arguments provided, never the argument VALUES.
+  // Log the SHAPE of the call only — tool name + argument names, never values.
   log.debug('mcp post body', paramsSummary(body?.params));
 
   log.debug('mcp post request', {
@@ -193,11 +122,9 @@ async function handleMCPPost(req: Request) {
     auth: maskToken(req.headers.get('Authorization')),
   });
 
-  // Right now, the MCP spec is inconsistent on _when_ 401s can be returned. So
-  // we always do the auth check, including for init.
+  // Always auth-check (including init) — the MCP spec is inconsistent on when
+  // 401s may be returned.
   if(!await userIsAuthenticated(req)){
-    // If a token was presented but failed validation, signal invalid_token so the
-    // client refreshes; if none was sent, send a bare challenge to start auth.
     const tokenPresented = !!req.headers.get('authorization');
     log.debug('mcp auth failed', { tokenPresented });
     return returnNeedsAuthResponse(tokenPresented
@@ -218,27 +145,71 @@ async function handleMCPPost(req: Request) {
     addLogContext({ toolName: body?.params?.name });
     log.info('tool call', paramsSummary(body?.params));
   } else if (body?.method === 'tools/list') {
-    // Tool discovery — pair this with the 'mcp server built' line (which reports
-    // toolCount/tools) to see exactly what a client is offered.
     log.info('tools list requested');
   }
 
+  const verboseMode = new URL(req.url).searchParams.get('verbose') === 'true';
+
   // Reconstruct a request with the buffered body so the v2 handler can read it
-  // (we already consumed req's stream above). v2's fetch is web-standard, so no
-  // Node req/res bridge is needed.
+  // (req's stream was consumed above).
   const reqWithBody = new Request(req.url, {
     method: req.method,
     headers: req.headers,
     body: JSON.stringify(body),
   });
 
-  const response = await mcpHandler.fetch(reqWithBody);
+  // Build the MCP server for THIS request. The factory closes over the request +
+  // parsed body so tools read the token (getNetlifyAccessToken) and client
+  // detection behave exactly as on v1. createMcpHandler serves whichever protocol
+  // era the client speaks (ctx.era: legacy=2025 | modern=2026-07-28).
+  const handler = createMcpHandler(
+    async (ctx) => {
+      const server = new McpServer({ name: "netlify", version: getPackageVersion() });
+
+      const contextConsumer = await getContextConsumerConfig();
+      const availableContextTypes = Object.keys(contextConsumer?.contextScopes || {});
+      const creationTypeEnum = z.enum(availableContextTypes as [string, ...string[]]);
+
+      server.registerTool(
+        "get-netlify-coding-context",
+        {
+          description:
+            "ALWAYS call when writing code. Required step before creating or editing any type of functions, Netlify sdk/library usage, etc. Use other operations for project management.",
+          inputSchema: { creationType: creationTypeEnum },
+          annotations: { readOnlyHint: true },
+        },
+        async ({ creationType }) => {
+          checkCompatibility();
+          const context = await getNetlifyCodingContext(creationType);
+          return { content: [{ type: "text" as const, text: context?.content || "" }] };
+        },
+      );
+
+      // Claude-only top-level design-import tool (detected from the request/body).
+      if (isClaudeMCPClient(req, body)) {
+        registerClaudeDesignImportTool(server, req);
+      }
+
+      // All Netlify domain tools. A failure here shouldn't sink the whole request
+      // (coding-context still works), so log and continue.
+      try {
+        await bindTools(server, req, verboseMode);
+      } catch (error) {
+        log.error('Failed to bind domain tools', { err: error });
+      }
+
+      log.info('mcp server built', { era: ctx.era, verboseMode, domainToolsRegistered: true });
+      return server;
+    },
+    { onerror: (error: Error) => log.error("mcp handler error", { err: error }) },
+  );
+
+  const response = await handler.fetch(reqWithBody);
 
   try {
     const returnData = await response.clone().text();
 
-    // Log response metadata only — status, type, and size — never the body,
-    // which contains tool result values (env vars, form data, project details).
+    // Log response metadata only — never the body (tool result values).
     log.debug('mcp response', {
       status: response.status,
       contentType: response.headers.get('content-type'),
@@ -246,8 +217,6 @@ async function handleMCPPost(req: Request) {
     });
 
     if(returnData.includes(UNAUTHED_ERROR_PREFIX)){
-      // A downstream Netlify call rejected the token mid-request — it's no longer
-      // valid, so flag invalid_token rather than a bare challenge.
       log.error("Unauthorized error detected in response");
       return returnNeedsAuthResponse({ error: 'invalid_token', errorDescription: 'The Netlify access token is no longer valid' });
     }
@@ -267,10 +236,7 @@ function jsonRpcError(status: number, code: number, message: string) {
       error: { code, message },
       id: null,
     }),
-    {
-      status,
-      headers: { "Content-Type": "application/json" }
-    }
+    { status, headers: { "Content-Type": "application/json" } }
   );
 }
 

--- a/netlify/functions/mcp.ts
+++ b/netlify/functions/mcp.ts
@@ -1,15 +1,20 @@
-import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
-import { toFetchResponse, toReqRes } from "fetch-to-node";
-import { addCORSHeadersToFetchResp, addCommonHeadersToHandlerResp, headersToHeadersObject, returnNeedsAuthResponse } from "./mcp-server/utils.ts";
+// SPIKE: migrated to the MCP TypeScript SDK v2 (@modelcontextprotocol/server,
+// 2.0.0-beta.4) to support the 2026-07-28 protocol. v2's createMcpHandler serves
+// BOTH 2026-07-28 (modern) and 2025-era (legacy) traffic from one web-standard
+// (Request)=>Response handler — replacing v1's StreamableHTTPServerTransport +
+// fetch-to-node bridge.
+//
+// DEFERRED (not in this spike): bindTools (all domain tools) and the Claude
+// design-import tool. Those register schemas built with zod v3, but v2's
+// registerTool types against `zod/v4`. Migrating them is the remaining lift —
+// see SPIKE note below. Only get-netlify-coding-context is wired here to prove
+// the transport + dual-era serving end to end.
+import { createMcpHandler, McpServer } from "@modelcontextprotocol/server";
+import { addCORSHeadersToFetchResp, returnNeedsAuthResponse } from "./mcp-server/utils.ts";
 import { getContextConsumerConfig, getNetlifyCodingContext } from "../../src/context/coding-context.ts";
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { getPackageVersion } from "../../src/utils/version.ts";
-import { z } from "zod";
 import { checkCompatibility } from "../../src/utils/compatibility.ts";
-import { bindTools } from "../../src/tools/index.ts";
-import { registerClaudeDesignImportTool } from "../../src/tools/design-import/import-claude-design.ts";
 import { userIsAuthenticated, getTokenIdentity, UNAUTHED_ERROR_PREFIX } from "../../src/utils/api-networking.ts";
-import { isClaudeMCPClient } from "../../src/utils/client-detection.ts";
 import { maskToken, paramsSummary } from "./mcp-server/logging.ts";
 import { log, withLogContext, addLogContext, newRequestId, initLogger, getDeployId } from "./mcp-server/logger.ts";
 import { systemLogForwarder } from "./mcp-server/system-log-forwarder.ts";
@@ -19,13 +24,56 @@ import {Config, Context} from "@netlify/functions";
 // function. Runs once at cold start; edge/CLI keep the default console forwarder.
 initLogger({ forward: systemLogForwarder });
 
+// The v2 handler is created once. Its factory runs per request and returns a
+// fresh McpServer; `era` (legacy|modern) lets the same handler serve both
+// protocol revisions. Auth is pass-through — we gate in front and the tools
+// read the token from the request themselves (unchanged from v1).
+const mcpHandler = createMcpHandler(
+  async () => {
+    const server = new McpServer({
+      name: "netlify",
+      version: getPackageVersion(),
+    });
+
+    const contextConsumer = await getContextConsumerConfig();
+    const availableContextTypes = Object.keys(contextConsumer?.contextScopes || {});
+
+    // SPIKE: registered WITHOUT an inputSchema. The real tool takes a
+    // `creationType` enum built with zod v3, but v2's registerTool types
+    // inputSchema against zod v4 (the SDK depends on zod@^4.2.0; the project is
+    // on zod@3.25.76). Proving the transport here; the schema'd registration
+    // returns once the project moves to zod v4 (same lift as bindTools).
+    server.registerTool(
+      "get-netlify-coding-context",
+      {
+        description:
+          "ALWAYS call when writing code. Required step before creating or editing any type of functions, Netlify sdk/library usage, etc. Use other operations for project management.",
+        annotations: { readOnlyHint: true },
+      },
+      async () => {
+        checkCompatibility();
+        const context = await getNetlifyCodingContext(availableContextTypes[0]);
+        return { content: [{ type: "text" as const, text: context?.content || "" }] };
+      },
+    );
+
+    // SPIKE TODO: register the domain tools + Claude design-import here once
+    // their zod v3 schemas are migrated to zod/v4 (v2's registerTool types
+    // inputSchema against zod/v4). Today `bindTools(server, req, verboseMode)`
+    // and `registerClaudeDesignImportTool(server, req)` would not type-check
+    // against the v2 McpServer.
+    return server;
+  },
+  { onerror: (error: Error) => log.error("mcp handler error", { err: error }) },
+);
+
 // Netlify serverless function handler
 export default async (req: Request, context: Context) => {
 
   const url = new URL(req.url);
 
   // Establish the request-scoped log context up front so every line — including
-  // ones emitted deep in tool/API code — carries service/requestId/version and
+  // ones emitted deep in tool/API code — carries service/requestId/deployId and
   // the HTTP method+path. Auth later enriches this with userId/teamId.
   return withLogContext(
     {
@@ -118,45 +166,20 @@ async function handleMCPPost(req: Request) {
   });
 
   // Log the SHAPE of the call only — the tool name and the names of the
-  // arguments provided, never the argument VALUES. Tool arguments (and tool
-  // results, see the response log below) routinely carry secrets/PII: env var
-  // values, form submissions, project data. So we deliberately never log those
-  // values, only their property names.
+  // arguments provided, never the argument VALUES.
   log.debug('mcp post body', paramsSummary(body?.params));
 
-  // Request headers relevant to StreamableHTTP/MCP negotiation. `accept` must
-  // include both application/json and text/event-stream or the transport rejects
-  // the request; session/protocol headers help correlate the handshake.
   log.debug('mcp post request', {
     accept: req.headers.get('accept'),
     contentType: req.headers.get('content-type'),
     mcpSessionId: req.headers.get('mcp-session-id'),
-    // origin/referer identify which surface a request comes from; kept for
-    // diagnosing client behaviour when verbose logging is enabled.
     origin: req.headers.get('origin'),
     referer: req.headers.get('referer'),
     auth: maskToken(req.headers.get('Authorization')),
   });
 
-  // Check for verbose mode via query parameter
-  const url = new URL(req.url);
-  const verboseMode = url.searchParams.get('verbose') === 'true';
-  log.debug('mcp post handling', { verboseMode });
-
-  // Create a new Request with the body as a string to avoid re-reading issues
-  // toReqRes will try to read the body, so we need to provide a fresh request
-  const reqWithBody = new Request(req.url, {
-    method: req.method,
-    headers: req.headers,
-    body: JSON.stringify(body),
-  });
-
-  // Convert the Request object into a Node.js Request object
-  const { req: nodeReq, res: nodeRes } = toReqRes(reqWithBody);
-
-  // Right now, the MCP spec is inconcistent on _when_ 
-  // 401s can be returned. So, we will always do the auth
-  // check, including for init.
+  // Right now, the MCP spec is inconsistent on _when_ 401s can be returned. So
+  // we always do the auth check, including for init.
   if(!await userIsAuthenticated(req)){
     // If a token was presented but failed validation, signal invalid_token so the
     // client refreshes; if none was sent, send a bare challenge to start auth.
@@ -166,9 +189,9 @@ async function handleMCPPost(req: Request) {
       ? { error: 'invalid_token', errorDescription: 'The access token is invalid or expired' }
       : undefined);
   }
+
   // Attach the caller's identity (embedded in the JWE at auth time) to the log
   // context so every subsequent line for this request is attributed to them.
-  // Null for raw PATs or pre-identity tokens — logs simply carry no user fields.
   const identity = await getTokenIdentity(req);
   if (identity) {
     addLogContext({ userId: identity.userId, teamId: identity.teamId });
@@ -176,83 +199,22 @@ async function handleMCPPost(req: Request) {
 
   log.debug('mcp request auth passed');
 
-  // Always-on record of each tool invocation (value-free — tool name + argument
-  // names only, via paramsSummary). Other JSON-RPC methods (initialize,
-  // tools/list, …) stay at debug so steady-state logs aren't noisy.
   if (body?.method === 'tools/call') {
-    // Put the tool name in the request context so everything downstream — the
-    // tool call line AND any 'netlify api call failed' lines from within it —
-    // is attributed to this tool.
     addLogContext({ toolName: body?.params?.name });
     log.info('tool call', paramsSummary(body?.params));
   }
 
-  const server = new McpServer({
-    name: "netlify",
-    title: "Netlify",
-    version: getPackageVersion(),
-    websiteUrl: "https://www.netlify.com",
-    icons: [{ src: "https://www.netlify.com/favicon/icon.svg", mimeType: "image/svg+xml" }],
+  // Reconstruct a request with the buffered body so the v2 handler can read it
+  // (we already consumed req's stream above). v2's fetch is web-standard, so no
+  // Node req/res bridge is needed.
+  const reqWithBody = new Request(req.url, {
+    method: req.method,
+    headers: req.headers,
+    body: JSON.stringify(body),
   });
 
-  const contextConsumer = await getContextConsumerConfig();
-  const availableContextTypes = Object.keys(contextConsumer?.contextScopes || {});
-  const creationTypeEnum = z.enum(availableContextTypes as [string, ...string[]]);
-  
-  server.tool(
-    "get-netlify-coding-context",
-    "ALWAYS call when writing code. Required step before creating or editing any type of functions, Netlify sdk/library  usage, etc. Use other operations for project management.",
-    { creationType: creationTypeEnum },
-    async ({creationType}: {creationType: z.infer<typeof creationTypeEnum>}) => {
-  
-      checkCompatibility();
-  
-      const context = await getNetlifyCodingContext(creationType);
-      const text = context?.content || '';
-  
-      return ({
-        content: [{type: "text", text}]
-      });
-    }
-  );
+  const response = await mcpHandler.fetch(reqWithBody);
 
-  // Standalone top-level tool (not part of the domain selector) so Claude Design
-  // can discover it by its exact name and list Netlify as a "Send to" destination.
-  // Registered only for Claude clients, which keeps it out of every non-Claude
-  // agent's tools/list. Within Claude it can still surface on other surfaces
-  // (Claude Code, claude.ai chat) because they share the connector's MCP URL and
-  // Claude does not filter tools per surface today; a per-URL marker is not an
-  // option since that URL is inherited from the claude.ai connector.
-  if (isClaudeMCPClient(req, body)) {
-    registerClaudeDesignImportTool(server, req);
-  }
-
-  try {
-    await bindTools(server, req, verboseMode);
-  } catch (error: any) {
-
-    log.error('Failed to bind tools to MCP server', { err: error });
-    return new Response('Failed to bind tools to MCP server', {status: 500});
-  }
-
-  const transport = new StreamableHTTPServerTransport({
-    sessionIdGenerator: undefined,
-  });
-
-  transport.onerror = (error) => {
-    log.error("Transport error", { err: error });
-  };
-
-  await server.connect(transport);
-
-  await transport.handleRequest(nodeReq, nodeRes, body);
-
-  nodeRes.on("close", () => {
-    transport.close();
-    server.close();
-  });
-
-  const response = await toFetchResponse(nodeRes);
   try {
     const returnData = await response.clone().text();
 
@@ -293,9 +255,7 @@ function jsonRpcError(status: number, code: number, message: string) {
   );
 }
 
-// For the stateless server, GET requests are used to initialize
-// SSE connections which are stateful. Therefore, we don't need
-// to handle GET requests but we can signal to the client this error.
+// Stateless server: GET/DELETE (2025 session operations) aren't supported.
 function handleMCPGet() {
   return jsonRpcError(405, -32002, "Method not allowed.");
 }
@@ -306,8 +266,6 @@ function handleMCPDelete() {
 
 
 // Ensure this function responds to the <domain>/mcp path
-// This can be any path you want but you'll need to ensure the
-// mcp server config you use/share matches this path.
 export const config: Config = {
   path: ["/mcp"],
 };

--- a/netlify/functions/mcp.ts
+++ b/netlify/functions/mcp.ts
@@ -102,12 +102,25 @@ async function handleMCPPost(req: Request) {
   }
 
   // Fold the MCP call identity into the request context so every subsequent line
-  // is attributed to this JSON-RPC call.
+  // is attributed to this JSON-RPC call. The `initialize` request additionally
+  // carries the version the client is REQUESTING (params.protocolVersion) — the
+  // mcp-protocol-version HEADER is absent on init and only reports the negotiated
+  // version on later requests, so the body is the only place the requested
+  // version appears. Client title and the NAMES of declared capabilities are
+  // safe, value-free shape; capabilities on non-init requests are undefined and
+  // simply omitted from the log line.
+  const clientCapabilities = body?.params?.capabilities;
   addLogContext({
     mcpMethod: body?.method,
     mcpId: body?.id,
     clientInfoName: body?.params?.clientInfo?.name,
     clientInfoVersion: body?.params?.clientInfo?.version,
+    clientInfoTitle: body?.params?.clientInfo?.title,
+    mcpProtocolVersionRequested: body?.params?.protocolVersion,
+    clientCapabilities:
+      clientCapabilities && typeof clientCapabilities === 'object'
+        ? Object.keys(clientCapabilities)
+        : undefined,
   });
 
   // Log the SHAPE of the call only — tool name + argument names, never values.

--- a/netlify/functions/mcp.ts
+++ b/netlify/functions/mcp.ts
@@ -181,22 +181,30 @@ async function handleMCPPost(req: Request) {
 
       const contextConsumer = await getContextConsumerConfig();
       const availableContextTypes = Object.keys(contextConsumer?.contextScopes || {});
-      const creationTypeEnum = z.enum(availableContextTypes as [string, ...string[]]);
 
-      server.registerTool(
-        "get-netlify-coding-context",
-        {
-          description:
-            "ALWAYS call when writing code. Required step before creating or editing any type of functions, Netlify sdk/library usage, etc. Use other operations for project management.",
-          inputSchema: { creationType: creationTypeEnum },
-          annotations: { readOnlyHint: true },
-        },
-        async ({ creationType }) => {
-          checkCompatibility();
-          const context = await getNetlifyCodingContext(creationType);
-          return { content: [{ type: "text" as const, text: context?.content || "" }] };
-        },
-      );
+      // Only register the coding-context tool when we actually have scopes to
+      // offer. With no scopes (e.g. the consumer config failed to fetch at cold
+      // start), z.enum([]) yields an uncallable tool — its required creationType
+      // can satisfy no value — so skip it until scopes become available. Normal
+      // enum construction proceeds whenever at least one scope exists.
+      if (availableContextTypes.length > 0) {
+        const creationTypeEnum = z.enum(availableContextTypes as [string, ...string[]]);
+
+        server.registerTool(
+          "get-netlify-coding-context",
+          {
+            description:
+              "ALWAYS call when writing code. Required step before creating or editing any type of functions, Netlify sdk/library usage, etc. Use other operations for project management.",
+            inputSchema: { creationType: creationTypeEnum },
+            annotations: { readOnlyHint: true },
+          },
+          async ({ creationType }) => {
+            checkCompatibility();
+            const context = await getNetlifyCodingContext(creationType);
+            return { content: [{ type: "text" as const, text: context?.content || "" }] };
+          },
+        );
+      }
 
       // Claude-only top-level design-import tool (detected from the request/body).
       if (isClaudeMCPClient(req, body)) {
@@ -204,14 +212,17 @@ async function handleMCPPost(req: Request) {
       }
 
       // All Netlify domain tools. A failure here shouldn't sink the whole request
-      // (coding-context still works), so log and continue.
+      // (coding-context still works), so log and continue. Track whether
+      // registration actually completed so the telemetry below reflects reality.
+      let domainToolsRegistered = false;
       try {
         await bindTools(server, req, verboseMode);
+        domainToolsRegistered = true;
       } catch (error) {
         log.error('Failed to bind domain tools', { err: error });
       }
 
-      log.info('mcp server built', { era: ctx.era, verboseMode, domainToolsRegistered: true });
+      log.info('mcp server built', { era: ctx.era, verboseMode, domainToolsRegistered });
       return server;
     },
     { onerror: (error: Error) => log.error("mcp handler error", { err: error }) },

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "ISC",
       "dependencies": {
         "@modelcontextprotocol/core": "2.0.0-beta.4",
-        "@modelcontextprotocol/sdk": "^1.29.0",
         "@modelcontextprotocol/server": "2.0.0-beta.4",
         "@netlify/edge-functions": "^2.15.0",
         "@netlify/functions": "^4.1.4",
@@ -20,7 +19,7 @@
         "jose": "^6.0.11",
         "oidc-provider": "^9.1.3",
         "serverless-http": "^3.2.0",
-        "zod": "^3.25.76",
+        "zod": "^4.4.3",
         "zod-to-json-schema": "^3.24.5"
       },
       "bin": {
@@ -510,18 +509,6 @@
       "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-3.1.1.tgz",
       "integrity": "sha512-5DGmA8FTdB2XbDeEwc/5ZXBl6UbBAyBOOLlPuBnZ/N1SwdH9Ii+cOX3tBROlDgcTXxjOYnLMVoKk9+FXAw0CJw=="
     },
-    "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.14.1"
-      },
-      "peerDependencies": {
-        "hono": "^4"
-      }
-    },
     "node_modules/@humanwhocodes/momoa": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/momoa/-/momoa-2.0.4.tgz",
@@ -670,55 +657,6 @@
         "node": ">=20"
       }
     },
-    "node_modules/@modelcontextprotocol/core/node_modules/zod": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
-      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
-      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@hono/node-server": "^1.19.9",
-        "ajv": "^8.17.1",
-        "ajv-formats": "^3.0.1",
-        "content-type": "^1.0.5",
-        "cors": "^2.8.5",
-        "cross-spawn": "^7.0.5",
-        "eventsource": "^3.0.2",
-        "eventsource-parser": "^3.0.0",
-        "express": "^5.2.1",
-        "express-rate-limit": "^8.2.1",
-        "hono": "^4.11.4",
-        "jose": "^6.1.3",
-        "json-schema-typed": "^8.0.2",
-        "pkce-challenge": "^5.0.0",
-        "raw-body": "^3.0.0",
-        "zod": "^3.25 || ^4.0",
-        "zod-to-json-schema": "^3.25.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@cfworker/json-schema": "^4.1.1",
-        "zod": "^3.25 || ^4.0"
-      },
-      "peerDependenciesMeta": {
-        "@cfworker/json-schema": {
-          "optional": true
-        },
-        "zod": {
-          "optional": false
-        }
-      }
-    },
     "node_modules/@modelcontextprotocol/server": {
       "version": "2.0.0-beta.4",
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server/-/server-2.0.0-beta.4.tgz",
@@ -730,15 +668,6 @@
       },
       "engines": {
         "node": ">=20"
-      }
-    },
-    "node_modules/@modelcontextprotocol/server/node_modules/zod": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
-      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@netlify/binary-info": {
@@ -944,6 +873,15 @@
       },
       "engines": {
         "node": ">=18.14.0"
+      }
+    },
+    "node_modules/@netlify/zip-it-and-ship-it/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -1722,19 +1660,6 @@
         "node": ">=6.5"
       }
     },
-    "node_modules/accepts": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
-      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-types": "^3.0.0",
-        "negotiator": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -1776,23 +1701,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/ajv-formats": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
-      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "ajv": {
-          "optional": true
-        }
       }
     },
     "node_modules/ansi-regex": {
@@ -1944,30 +1852,6 @@
         "file-uri-to-path": "1.0.0"
       }
     },
-    "node_modules/body-parser": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
-      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
-      "license": "MIT",
-      "dependencies": {
-        "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
-        "debug": "^4.4.3",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.7.0",
-        "on-finished": "^2.4.1",
-        "qs": "^6.14.1",
-        "raw-body": "^3.0.1",
-        "type-is": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
     "node_modules/brace-expansion": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
@@ -2095,35 +1979,6 @@
       },
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/call-bind-apply-helpers": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
-      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/call-bound": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
-      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "get-intrinsic": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/callsite": {
@@ -2358,43 +2213,12 @@
         "node": "^14.18.0 || >=16.10.0"
       }
     },
-    "node_modules/content-disposition": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
-      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
     "node_modules/content-type": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
       "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/cookie": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
-      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/cookie-signature": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
-      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.6.0"
       }
     },
     "node_modules/cookies": {
@@ -2428,18 +2252,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
-    },
-    "node_modules/cors": {
-      "version": "2.8.5",
-      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
-      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
-      "dependencies": {
-        "object-assign": "^4",
-        "vary": "^1"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
     },
     "node_modules/crc-32": {
       "version": "1.2.2",
@@ -2696,20 +2508,6 @@
         "url": "https://dotenvx.com"
       }
     },
-    "node_modules/dunder-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
-      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.2.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -2768,40 +2566,10 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/es-define-property": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-errors": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
       "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="
-    },
-    "node_modules/es-object-atoms": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
-      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
     },
     "node_modules/esbuild": {
       "version": "0.25.5",
@@ -2939,15 +2707,6 @@
         "url": "https://github.com/eta-dev/eta?sponsor=1"
       }
     },
-    "node_modules/etag": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/event-target-shim": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
@@ -2962,25 +2721,6 @@
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
       "engines": {
         "node": ">=0.8.x"
-      }
-    },
-    "node_modules/eventsource": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.6.tgz",
-      "integrity": "sha512-l19WpE2m9hSuyP06+FbuUUf1G+R0SFLrtQfbRb9PRr+oimOfxQhgGCbVaXg5IvZyyTThJsxh6L/srkMiCeBPDA==",
-      "dependencies": {
-        "eventsource-parser": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/eventsource-parser": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.1.tgz",
-      "integrity": "sha512-VARTJ9CYeuQYb0pZEPbzi740OWFgpHe7AYJ2WFZVnUDUQp5Dk2yJUgF36YsZ81cOyxT0QxmXD2EQpapAouzWVA==",
-      "engines": {
-        "node": ">=18.0.0"
       }
     },
     "node_modules/execa": {
@@ -3014,67 +2754,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/express": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
-      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
-      "license": "MIT",
-      "dependencies": {
-        "accepts": "^2.0.0",
-        "body-parser": "^2.2.1",
-        "content-disposition": "^1.0.0",
-        "content-type": "^1.0.5",
-        "cookie": "^0.7.1",
-        "cookie-signature": "^1.2.1",
-        "debug": "^4.4.0",
-        "depd": "^2.0.0",
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "etag": "^1.8.1",
-        "finalhandler": "^2.1.0",
-        "fresh": "^2.0.0",
-        "http-errors": "^2.0.0",
-        "merge-descriptors": "^2.0.0",
-        "mime-types": "^3.0.0",
-        "on-finished": "^2.4.1",
-        "once": "^1.4.0",
-        "parseurl": "^1.3.3",
-        "proxy-addr": "^2.0.7",
-        "qs": "^6.14.0",
-        "range-parser": "^1.2.1",
-        "router": "^2.2.0",
-        "send": "^1.1.0",
-        "serve-static": "^2.2.0",
-        "statuses": "^2.0.1",
-        "type-is": "^2.0.1",
-        "vary": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/express-rate-limit": {
-      "version": "8.5.2",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
-      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
-      "license": "MIT",
-      "dependencies": {
-        "ip-address": "^10.2.0"
-      },
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/express-rate-limit"
-      },
-      "peerDependencies": {
-        "express": ">= 4.11"
       }
     },
     "node_modules/extract-zip": {
@@ -3219,27 +2898,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/finalhandler": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
-      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.4.0",
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "on-finished": "^2.4.1",
-        "parseurl": "^1.3.3",
-        "statuses": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 18.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
     "node_modules/find-up": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-7.0.0.tgz",
@@ -3287,24 +2945,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/forwarded": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
-      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/fresh": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
-      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -3347,30 +2987,6 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
-    "node_modules/get-intrinsic": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
-      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "es-define-property": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.1.1",
-        "function-bind": "^1.1.2",
-        "get-proto": "^1.0.1",
-        "gopd": "^1.2.0",
-        "has-symbols": "^1.1.0",
-        "hasown": "^2.0.2",
-        "math-intrinsics": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/get-package-name": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/get-package-name/-/get-package-name-2.2.0.tgz",
@@ -3388,19 +3004,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/get-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
-      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "license": "MIT",
-      "dependencies": {
-        "dunder-proto": "^1.0.1",
-        "es-object-atoms": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/get-stream": {
@@ -3458,18 +3061,6 @@
         "node": ">=0.6.0"
       }
     },
-    "node_modules/gopd": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -3483,18 +3074,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/has-symbols": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
-      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -3504,15 +3083,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/hono": {
-      "version": "4.12.24",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.24.tgz",
-      "integrity": "sha512-I36D1s+HgQc55KbhEr4iybfxv/9o1zdpw+XEM6dJa91LqQD0HCoSGdxpRJCZE+aavs87j4V3Ls2OJzq8C/U4iw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=16.9.0"
       }
     },
     "node_modules/hosted-git-info": {
@@ -3679,24 +3249,6 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
-    "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
-    "node_modules/ipaddr.js": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
-      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
     "node_modules/is-arrayish": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
@@ -3794,12 +3346,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/is-promise": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
-      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
-      "license": "MIT"
     },
     "node_modules/is-stream": {
       "version": "2.0.1",
@@ -3904,12 +3450,6 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
-    },
-    "node_modules/json-schema-typed": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
-      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
-      "license": "BSD-2-Clause"
     },
     "node_modules/jsonpointer": {
       "version": "5.0.1",
@@ -4210,33 +3750,12 @@
         "@jridgewell/sourcemap-codec": "^1.5.0"
       }
     },
-    "node_modules/math-intrinsics": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
-      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/media-typer": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
       "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/merge-descriptors": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
-      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/merge-options": {
@@ -4424,15 +3943,6 @@
         "node": "^18 || >=20"
       }
     },
-    "node_modules/negotiator": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
-      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/node-fetch": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
@@ -4568,20 +4078,9 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/object-inspect": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
-      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/oidc-provider": {
@@ -4833,16 +4332,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/path-to-regexp": {
-      "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
-      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
     "node_modules/pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
@@ -4871,14 +4360,6 @@
       "dev": true,
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/pkce-challenge": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.0.tgz",
-      "integrity": "sha512-ueGLflrrnvwB3xuo/uGob5pd5FN7l0MsLf0Z87o/UQmRtwjvfylfc9MurIxRAWywCYTgrvpXBcqjV4OfCYGCIQ==",
-      "engines": {
-        "node": ">=16.20.0"
       }
     },
     "node_modules/postcss": {
@@ -5032,19 +4513,6 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
-    "node_modules/proxy-addr": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
-      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
-      "license": "MIT",
-      "dependencies": {
-        "forwarded": "0.2.0",
-        "ipaddr.js": "1.9.1"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
     "node_modules/pump": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.2.tgz",
@@ -5061,21 +4529,6 @@
       "dev": true,
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/qs": {
-      "version": "6.15.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
-      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "side-channel": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/queue-microtask": {
@@ -5112,15 +4565,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/quote-unquote/-/quote-unquote-1.0.0.tgz",
       "integrity": "sha512-twwRO/ilhlG/FIgYeKGFqyHhoEhqgnKVkcmqMKi2r524gz3ZbDTcyFt38E9xjJI2vT+KbRNHVbnJ/e0I25Azwg=="
-    },
-    "node_modules/range-parser": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
     },
     "node_modules/raw-body": {
       "version": "3.0.2",
@@ -5323,22 +4767,6 @@
         "fsevents": "~2.3.2"
       }
     },
-    "node_modules/router": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
-      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.4.0",
-        "depd": "^2.0.0",
-        "is-promise": "^4.0.0",
-        "parseurl": "^1.3.3",
-        "path-to-regexp": "^8.0.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -5404,51 +4832,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/send": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
-      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.4.3",
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "etag": "^1.8.1",
-        "fresh": "^2.0.0",
-        "http-errors": "^2.0.1",
-        "mime-types": "^3.0.2",
-        "ms": "^2.1.3",
-        "on-finished": "^2.4.1",
-        "range-parser": "^1.2.1",
-        "statuses": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/serve-static": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
-      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
-      "license": "MIT",
-      "dependencies": {
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "parseurl": "^1.3.3",
-        "send": "^1.2.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
     "node_modules/serverless-http": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/serverless-http/-/serverless-http-3.2.0.tgz",
@@ -5479,78 +4862,6 @@
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
-        "side-channel-map": "^1.0.1",
-        "side-channel-weakmap": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/side-channel-list": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
-      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.4"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/side-channel-map": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
-      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.5",
-        "object-inspect": "^1.13.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/side-channel-weakmap": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
-      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.5",
-        "object-inspect": "^1.13.3",
-        "side-channel-map": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/signal-exit": {
@@ -6493,9 +5804,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,9 @@
       "version": "1.15.1",
       "license": "ISC",
       "dependencies": {
+        "@modelcontextprotocol/core": "2.0.0-beta.4",
         "@modelcontextprotocol/sdk": "^1.29.0",
+        "@modelcontextprotocol/server": "2.0.0-beta.4",
         "@netlify/edge-functions": "^2.15.0",
         "@netlify/functions": "^4.1.4",
         "archiver": "^7.0.1",
@@ -656,6 +658,27 @@
         "node": ">=18"
       }
     },
+    "node_modules/@modelcontextprotocol/core": {
+      "version": "2.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/core/-/core-2.0.0-beta.4.tgz",
+      "integrity": "sha512-nsMXd4wQBKzmph6r+WOhum+mXjDYljTAqwY/XUg3hLtvNOQ8+JVqBSJOVCMJvx9lXhTpTOPrGZ3BuNiaNPjSvg==",
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@modelcontextprotocol/core/node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.29.0",
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
@@ -694,6 +717,28 @@
         "zod": {
           "optional": false
         }
+      }
+    },
+    "node_modules/@modelcontextprotocol/server": {
+      "version": "2.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server/-/server-2.0.0-beta.4.tgz",
+      "integrity": "sha512-pjMZcNEt1dOq0aJCcY3b7w1Ayh+qmQN2xlfTELcGV9yiAjEGIczBPBLWWW0k0zzo5T8kiv15jtKPsWeHGxLvLg==",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/core": "2.0.0-beta.4",
+        "zod": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@modelcontextprotocol/server/node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@netlify/binary-info": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@modelcontextprotocol/core": "2.0.0-beta.4",
     "@modelcontextprotocol/sdk": "^1.29.0",
+    "@modelcontextprotocol/server": "2.0.0-beta.4",
     "@netlify/edge-functions": "^2.15.0",
     "@netlify/functions": "^4.1.4",
     "archiver": "^7.0.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   "license": "ISC",
   "dependencies": {
     "@modelcontextprotocol/core": "2.0.0-beta.4",
-    "@modelcontextprotocol/sdk": "^1.29.0",
     "@modelcontextprotocol/server": "2.0.0-beta.4",
     "@netlify/edge-functions": "^2.15.0",
     "@netlify/functions": "^4.1.4",
@@ -31,7 +30,7 @@
     "jose": "^6.0.11",
     "oidc-provider": "^9.1.3",
     "serverless-http": "^3.2.0",
-    "zod": "^3.25.76",
+    "zod": "^4.4.3",
     "zod-to-json-schema": "^3.24.5"
   },
   "devDependencies": {

--- a/src/tools/design-import/import-claude-design.ts
+++ b/src/tools/design-import/import-claude-design.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { McpServer } from '@modelcontextprotocol/server';
 import path from 'node:path';
 import os from 'node:os';
 import { promises as fs } from 'node:fs';

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -22,7 +22,7 @@
 // return errors when missing data and how the agent can get the data
 
 
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { McpServer } from '@modelcontextprotocol/server';
 import { userDomainTools } from './user-tools/index.js';
 import { deployDomainTools } from './deploy-tools/index.js';
 import { teamDomainTools } from './team-tools/index.js';

--- a/src/tools/types.ts
+++ b/src/tools/types.ts
@@ -1,4 +1,4 @@
-import { ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
+import type { ToolAnnotations } from '@modelcontextprotocol/server';
 import { z } from 'zod';
 
 export interface DomainTool<T extends z.ZodType> {


### PR DESCRIPTION
- migrate netlify/functions/mcp.ts to @modelcontextprotocol/server v2 createMcpHandler (web-standard fetch), replacing v1 transport + fetch-to-node
- proven: one handler serves both 2026-07-28 (modern) and 2025-era clients
- bindTools + design-import deferred pending zod v3->v4 upgrade (see SPIKE_FINDINGS.md)