### PR TITLE
fix: avoid double slash in remote deploy proxy URL

### DIFF
--- a/src/tools/deploy-tools/deploy-site.test.ts
+++ b/src/tools/deploy-tools/deploy-site.test.ts
@@ -1,0 +1,25 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+test('remote deploy-site builds a proxy URL with no double slash', async () => {
+  // A bare-origin issuer is what production uses; getOAuthIssuer()
+  // canonicalizes it to include a trailing slash, and the proxy URL
+  // construction must tolerate that.
+  process.env.OAUTH_ISSUER = 'https://netlify-mcp.netlify.app';
+  process.env.JWE_SECRET = 'test-secret-0123456789abcdef0123456789abcdef';
+
+  // Import after the env is set so module state picks up the test values.
+  const { deploySiteRemotelyDomainTool } = await import('./deploy-site.ts');
+
+  const request = new Request('https://netlify-mcp.netlify.app/mcp', {
+    headers: { Authorization: 'Bearer nfp_test_token' },
+  });
+  const result = await deploySiteRemotelyDomainTool.cb({ siteId: 'site-123' }, { request });
+
+  const proxyUrl = /--proxy-path "([^"]+)"/.exec(result)?.[1];
+  assert.ok(proxyUrl, `no --proxy-path in tool output: ${result}`);
+  assert.ok(
+    proxyUrl.startsWith('https://netlify-mcp.netlify.app/proxy/'),
+    `proxy URL must hit the /proxy/:token/* route, got: ${proxyUrl}`,
+  );
+});

--- a/src/tools/deploy-tools/deploy-site.ts
+++ b/src/tools/deploy-tools/deploy-site.ts
@@ -43,14 +43,14 @@ export const deploySiteRemotelyDomainTool: DomainTool<typeof deploySiteRemotelyP
       ]
     }, '30m');
 
-    const proxyPath = `/proxy/${proxyToken}`;
-    
+    const proxyUrl = new URL(`/proxy/${proxyToken}`, getOAuthIssuer()).toString();
+
     return `
 
 To deploy this to Netlify, run the following command within the source/repo directory:
 
 \`\`\`shell
-npx -y @netlify/mcp@latest --site-id ${params.siteId} --proxy-path "${getOAuthIssuer()}${proxyPath}"
+npx -y @netlify/mcp@latest --site-id ${params.siteId} --proxy-path "${proxyUrl}"
 \`\`\`
 
 This command will upload the code repo and run a build in Netlify's build system.

--- a/src/tools/deploy-tools/deploy-site.ts
+++ b/src/tools/deploy-tools/deploy-site.ts
@@ -10,7 +10,7 @@ import path from "path";
 import { randomUUID } from "crypto";
 import { rm } from "fs/promises";
 import { authenticatedFetch, getNetlifyAccessToken, getSiteId, unauthenticatedFetch } from "../../utils/api-networking.ts";
-import { createJWE, getOAuthIssuer } from '../../../netlify/functions/mcp-server/utils.js';
+import { createJWE, getOAuthIssuer } from '../../../netlify/functions/mcp-server/utils.ts';
 
 const deploySiteRemotelyParamsSchema = z.object({
   siteId: z.string().optional().describe(`provide the site id of the site of this site. If the agent cannot find the siteId, the user must confirm this is a new site. NEVER assume the user wants a new site. Use 'netlify link' CLI command to link to an existing site and get a site id.`)

--- a/src/utils/api-networking.ts
+++ b/src/utils/api-networking.ts
@@ -1,10 +1,10 @@
 import path from 'node:path';
 import * as fs from 'node:fs/promises';
 import envPaths from 'env-paths';
-import { runCommand } from './cmd.js';
-import { appendToLog } from './logging.js';
-import { decryptJWE } from '../../netlify/functions/mcp-server/utils.js';
-import { log } from '../../netlify/functions/mcp-server/logger.js';
+import { runCommand } from './cmd.ts';
+import { appendToLog } from './logging.ts';
+import { decryptJWE } from '../../netlify/functions/mcp-server/utils.ts';
+import { log } from '../../netlify/functions/mcp-server/logger.ts';
 import type { TokenIdentity } from '../../netlify/functions/mcp-server/identity.js';
 
 interface APIInteractionOptions {

--- a/src/utils/logging.ts
+++ b/src/utils/logging.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
-import { log } from '../../netlify/functions/mcp-server/logger.js';
+import { log } from '../../netlify/functions/mcp-server/logger.ts';
 
 /**
  * Appends a message to the log file


### PR DESCRIPTION
`getOAuthIssuer()` returns the issuer with a trailing slash since 805a507 (canonicalized via `new URL().toString()` for RFC 9207 `iss` matching). Concatenating `/proxy/<token>` onto it produces `https://host//proxy/...`, and the empty path segment doesn't match the `/proxy/:token/*` edge function route — so the remote `deploy-site` command 404s.

Fix: build the URL with `new URL(path, base)`, which is correct with or without a trailing slash on the issuer. This was the only call site concatenating `getOAuthIssuer()` with a path.

Includes a regression test that runs the tool and asserts the emitted `--proxy-path` matches the `/proxy/:token/*` route (a few `.js` import specifiers in the tool's chain switch to `.ts`, as `netlify/**` already uses, so `node --test` can load it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)