### PR TITLE
fix: return 401, not 500, for expired bearer and proxy tokens

### DIFF
--- a/netlify/edge-functions/proxy.ts
+++ b/netlify/edge-functions/proxy.ts
@@ -1,6 +1,6 @@
 import { decryptJWE } from "../functions/mcp-server/utils.ts";
 import { log, withLogContext, addLogContext, newRequestId, getDeployId } from "../functions/mcp-server/logger.ts";
-import {Config, Context} from '@netlify/edge-functions';
+import type {Config, Context} from '@netlify/edge-functions';
 
 // Escape regex metacharacters so an allowed-path template is matched literally
 // (except for our own `:param` placeholders, which are substituted afterwards).
@@ -27,13 +27,19 @@ export default async (req: Request, ctx: Context) => {
   );
 };
 
-async function handleProxy(req: Request, token: string): Promise<Response> {
+export async function handleProxy(req: Request, token: string): Promise<Response> {
   log.debug('proxy request', { url: req.url, hasToken: !!token });
 
   if (!token) {
     return new Response('Unauthorized', { status: 401 });
   }
-  const decryptedToken = await decryptJWE(token);
+  // decryptJWE throws on expired/invalid tokens — an auth failure, not a crash.
+  let decryptedToken: Record<string, any> | undefined;
+  try {
+    decryptedToken = await decryptJWE(token);
+  } catch {
+    return new Response('Unauthorized', { status: 401 });
+  }
   if (!decryptedToken || typeof decryptedToken.accessToken !== 'string') {
     return new Response('Unauthorized', { status: 401 });
   }

--- a/netlify/edge-functions/proxy.ts
+++ b/netlify/edge-functions/proxy.ts
@@ -28,7 +28,8 @@ export default async (req: Request, ctx: Context) => {
 };
 
 export async function handleProxy(req: Request, token: string): Promise<Response> {
-  log.debug('proxy request', { url: req.url, hasToken: !!token });
+  // Never log req.url — the path embeds the bearer token.
+  log.debug('proxy request', { hasToken: !!token, apiPath: token ? req.url.split(token)[1] : undefined });
 
   if (!token) {
     return new Response('Unauthorized', { status: 401 });

--- a/netlify/edge-functions/proxy.ts
+++ b/netlify/edge-functions/proxy.ts
@@ -28,13 +28,11 @@ export default async (req: Request, ctx: Context) => {
 };
 
 export async function handleProxy(req: Request, token: string): Promise<Response> {
-  // Never log req.url — the path embeds the bearer token.
   log.debug('proxy request', { hasToken: !!token, apiPath: token ? req.url.split(token)[1] : undefined });
 
   if (!token) {
     return new Response('Unauthorized', { status: 401 });
   }
-  // decryptJWE throws on expired/invalid tokens — an auth failure, not a crash.
   let decryptedToken: Record<string, any> | undefined;
   try {
     decryptedToken = await decryptJWE(token);

--- a/netlify/functions/mcp-server/utils.ts
+++ b/netlify/functions/mcp-server/utils.ts
@@ -254,7 +254,12 @@ export async function decryptJWE(jwe: string) {
       }
     }
 
-    log.error('Failed to decrypt JWE', errorDetails);
+    // Genuine expiry is routine (handled as 401 upstream) — warn. Everything
+    // else (clock skew, wrong key, malformed) stays error.
+    const isRoutineExpiry = error?.code === 'ERR_JWT_EXPIRED'
+      && typeof errorDetails.expiredBySeconds === 'number'
+      && errorDetails.expiredBySeconds > 0;
+    log[isRoutineExpiry ? 'warn' : 'error']('Failed to decrypt JWE', errorDetails);
     throw new Error('Invalid JWE token. Please reauthenticate or reconnect to the Netlify MCP server.')
   }
 }

--- a/netlify/functions/mcp-server/utils.ts
+++ b/netlify/functions/mcp-server/utils.ts
@@ -254,8 +254,6 @@ export async function decryptJWE(jwe: string) {
       }
     }
 
-    // Genuine expiry is routine (handled as 401 upstream) — warn. Everything
-    // else (clock skew, wrong key, malformed) stays error.
     const isRoutineExpiry = error?.code === 'ERR_JWT_EXPIRED'
       && typeof errorDetails.expiredBySeconds === 'number'
       && errorDetails.expiredBySeconds >= 0;

--- a/netlify/functions/mcp-server/utils.ts
+++ b/netlify/functions/mcp-server/utils.ts
@@ -258,7 +258,7 @@ export async function decryptJWE(jwe: string) {
     // else (clock skew, wrong key, malformed) stays error.
     const isRoutineExpiry = error?.code === 'ERR_JWT_EXPIRED'
       && typeof errorDetails.expiredBySeconds === 'number'
-      && errorDetails.expiredBySeconds > 0;
+      && errorDetails.expiredBySeconds >= 0;
     log[isRoutineExpiry ? 'warn' : 'error']('Failed to decrypt JWE', errorDetails);
     throw new Error('Invalid JWE token. Please reauthenticate or reconnect to the Netlify MCP server.')
   }

--- a/src/utils/api-networking.test.ts
+++ b/src/utils/api-networking.test.ts
@@ -1,0 +1,46 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { setTimeout as sleep } from 'node:timers/promises';
+
+// Expired or undecryptable bearers must surface as auth failures (401 /
+// invalid_token) so clients refresh — never as a 500 from an uncaught throw.
+
+process.env.OAUTH_ISSUER = 'https://netlify-mcp.netlify.app';
+process.env.JWE_SECRET = 'test-secret-0123456789abcdef0123456789abcdef';
+
+const requestWithBearer = (bearer: string) =>
+  new Request('https://netlify-mcp.netlify.app/mcp', {
+    headers: { Authorization: `Bearer ${bearer}` },
+  });
+
+test('an expired JWE bearer is an auth failure, not a thrown server error', async () => {
+  const { getNetlifyAccessToken, userIsAuthenticated, NetlifyUnauthError } = await import('./api-networking.ts');
+  const { createJWE } = await import('../../netlify/functions/mcp-server/utils.ts');
+
+  const expired = await createJWE({ accessToken: 'nfp_test' }, '1s');
+  await sleep(1500);
+
+  await assert.rejects(getNetlifyAccessToken(requestWithBearer(expired)), NetlifyUnauthError);
+  assert.equal(await userIsAuthenticated(requestWithBearer(expired)), false);
+});
+
+test('an undecryptable bearer is an auth failure, not a thrown server error', async () => {
+  const { getNetlifyAccessToken, userIsAuthenticated, NetlifyUnauthError } = await import('./api-networking.ts');
+
+  await assert.rejects(getNetlifyAccessToken(requestWithBearer('not-a-jwe')), NetlifyUnauthError);
+  assert.equal(await userIsAuthenticated(requestWithBearer('not-a-jwe')), false);
+});
+
+test('the deploy proxy returns 401 (not a crash) for an expired token', async () => {
+  const { handleProxy } = await import('../../netlify/edge-functions/proxy.ts');
+  const { createJWE } = await import('../../netlify/functions/mcp-server/utils.ts');
+
+  const expired = await createJWE({ accessToken: 'nfp_test' }, '1s');
+  await sleep(1500);
+
+  const resp = await handleProxy(
+    new Request(`https://netlify-mcp.netlify.app/proxy/${expired}/api/v1/deploys/x`, { method: 'GET' }),
+    expired,
+  );
+  assert.equal(resp.status, 401);
+});

--- a/src/utils/api-networking.test.ts
+++ b/src/utils/api-networking.test.ts
@@ -2,9 +2,6 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { setTimeout as sleep } from 'node:timers/promises';
 
-// Expired or undecryptable bearers must surface as auth failures (401 /
-// invalid_token) so clients refresh — never as a 500 from an uncaught throw.
-
 process.env.OAUTH_ISSUER = 'https://netlify-mcp.netlify.app';
 process.env.JWE_SECRET = 'test-secret-0123456789abcdef0123456789abcdef';
 

--- a/src/utils/api-networking.ts
+++ b/src/utils/api-networking.ts
@@ -103,8 +103,6 @@ export const getNetlifyAccessToken = async (request?: Request): Promise<string> 
         try {
           decrypted = await decryptJWE(bearerToken);
         } catch {
-          // Expired/undecryptable bearer is an auth failure (401 invalid_token
-          // so clients refresh), not a server error.
           throw new NetlifyUnauthError('Bearer token is invalid or expired');
         }
         if(decrypted && typeof decrypted.accessToken === 'string') {

--- a/src/utils/api-networking.ts
+++ b/src/utils/api-networking.ts
@@ -99,7 +99,14 @@ export const getNetlifyAccessToken = async (request?: Request): Promise<string> 
       if(bearerToken.startsWith('nfu') || bearerToken.startsWith('nfp') || bearerToken.startsWith('nfo')){
         token = bearerToken;
       }else {
-        const decrypted = await decryptJWE(bearerToken) ;
+        let decrypted: Record<string, any> | undefined;
+        try {
+          decrypted = await decryptJWE(bearerToken);
+        } catch {
+          // Expired/undecryptable bearer is an auth failure (401 invalid_token
+          // so clients refresh), not a server error.
+          throw new NetlifyUnauthError('Bearer token is invalid or expired');
+        }
         if(decrypted && typeof decrypted.accessToken === 'string') {
           token = decrypted.accessToken;
         } else {

--- a/src/utils/api-networking.ts
+++ b/src/utils/api-networking.ts
@@ -110,7 +110,7 @@ export const getNetlifyAccessToken = async (request?: Request): Promise<string> 
         if(decrypted && typeof decrypted.accessToken === 'string') {
           token = decrypted.accessToken;
         } else {
-          log.error('decrypted JWE did not contain accessToken', { fields: Object.keys(decrypted) });
+          log.error('decrypted JWE did not contain accessToken', { fields: Object.keys(decrypted ?? {}) });
         }
       }
 


### PR DESCRIPTION
`decryptJWE` throws on every decrypt failure, including `ERR_JWT_EXPIRED`. In the MCP auth path that throw escapes `getNetlifyAccessToken` → `userIsAuthenticated` (whose catch rethrows anything that isn't `NetlifyUnauthError`) → the catch-all in `mcp.ts`, so routine token expiry returns **500** instead of **401 + `WWW-Authenticate: invalid_token`**. Clients never get the refresh signal, so they keep retrying with the same dead token. The proxy edge function has the same bug: it null-checks `decryptJWE`'s result, but failures always throw — an expired deploy proxy token crashes it instead of 401ing.

Fix: convert decrypt failures to `NetlifyUnauthError` in the bearer path and a 401 response in the proxy. Token-grant paths (`auth-flow`, `client-registry`) intentionally keep the throwing contract. The `@netlify/edge-functions` import in `proxy.ts` becomes type-only (it exports no runtime values).

Tests cover expired JWE, undecryptable bearer, and expired proxy token; all three fail against the previous code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)