### PR TITLE
fix: prevent deploy-status watcher crash and guard API response body reads

### DIFF
--- a/netlify-mcp.ts
+++ b/netlify-mcp.ts
@@ -8,6 +8,7 @@ import { getPackageVersion } from "./src/utils/version.ts";
 import { checkCompatibility } from "./src/utils/compatibility.ts";
 import { bindTools } from "./src/tools/index.ts";
 import { zipAndBuild } from "./src/tools/deploy-tools/deploy-site.ts";
+import { checkDeployStatus } from "./src/tools/deploy-tools/deploy-watch.ts";
 
 // check to see if it's ran as a command to zip and build
 const proxyPath = process.argv[process.argv.indexOf('--proxy-path') + 1] || undefined;
@@ -42,22 +43,30 @@ if(process.argv.includes('--proxy-path') && proxyPath) {
     // states: new,pending_review,accepted,rejected,enqueued,building,uploading,uploaded,preparing,prepared,processing,ready,error,retrying
     // wait for the deploy to finish
     setInterval(async () => {
-      const deployLookup = await fetch(deployEndpoint);
-      if(deployLookup.ok) {
-        const deploy = await deployLookup.json();
-        if(deploy.state === 'ready') {
-          console.log('Deploy is ready!', JSON.stringify({ deployId, buildId, siteUrl: deploy.url }));
+      // checkDeployStatus never throws — a transient fetch/JSON failure here
+      // would otherwise become an unhandled rejection and kill the watcher
+      // mid-deploy. Poll errors are surfaced as { kind: 'poll-error' } so we
+      // log and keep polling.
+      const result = await checkDeployStatus(deployEndpoint);
+      switch (result.kind) {
+        case 'ready':
+          console.log('Deploy is ready!', JSON.stringify({ deployId, buildId, siteUrl: result.deploy.url }));
           process.exit(0);
-        }else if(deploy.state === 'error') {  
+        case 'error':
           console.error('Deploy failed!', JSON.stringify({ deployId, buildId, deployInfo: `https://app.netlify.com/sites/${siteId}/deploys/${deployId}` }));
           process.exit(1);
+        case 'unavailable':
+          console.error('Error fetching deploy status:', result.statusText);
+          process.exit(0);
+        case 'poll-error':
+          console.error('Error checking deploy status, will retry...', result.message);
+          break;
+        case 'pending': {
+          const sameAsLastState = lastState === result.state;
+          console.log(`This project deploy is ${sameAsLastState ? 'still' : 'now'} ${result.state}. Waiting for it to finish...`);
+          lastState = result.state;
+          break;
         }
-        const sameAsLastState = lastState === deploy.state;
-        console.log(`This project deploy is ${sameAsLastState ? 'still' : 'now'} ${deploy.state}. Waiting for it to finish...`);
-        lastState = deploy.state;
-      } else {
-        console.error('Error fetching deploy status:', deployLookup.statusText);
-        process.exit(0);
       }
     }, 5000);
 

--- a/src/tools/deploy-tools/deploy-watch.test.ts
+++ b/src/tools/deploy-tools/deploy-watch.test.ts
@@ -1,0 +1,73 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import { checkDeployStatus } from './deploy-watch.ts';
+
+const listen = (server: http.Server): Promise<number> =>
+  new Promise((resolve) => server.listen(0, () => resolve((server.address() as any).port)));
+
+test('checkDeployStatus does not throw when the endpoint is unreachable (watcher must not crash)', async () => {
+  // Port 1 refuses the connection, so fetch() rejects. The bare setInterval
+  // callback that used to do this inline would surface an unhandled rejection
+  // and terminate the deploy watcher.
+  const result = await checkDeployStatus('http://127.0.0.1:1/deploys/x');
+  assert.equal(result.kind, 'poll-error');
+});
+
+test('checkDeployStatus does not throw when the deploy body is not JSON', async () => {
+  const server = http.createServer((_req, res) => {
+    res.writeHead(200, { 'content-type': 'text/html' });
+    res.end('<html><body>502 Bad Gateway</body></html>');
+  });
+  const port = await listen(server);
+  try {
+    const result = await checkDeployStatus(`http://127.0.0.1:${port}/`);
+    assert.equal(result.kind, 'poll-error'); // .json() threw, but it was caught
+  } finally {
+    server.close();
+  }
+});
+
+test('checkDeployStatus reports ready with the parsed deploy', async () => {
+  const server = http.createServer((_req, res) => {
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ state: 'ready', url: 'https://example.netlify.app' }));
+  });
+  const port = await listen(server);
+  try {
+    const result = await checkDeployStatus(`http://127.0.0.1:${port}/`);
+    assert.equal(result.kind, 'ready');
+    assert.equal(result.kind === 'ready' && result.deploy.url, 'https://example.netlify.app');
+  } finally {
+    server.close();
+  }
+});
+
+test('checkDeployStatus reports a pending state without exiting', async () => {
+  const server = http.createServer((_req, res) => {
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ state: 'building' }));
+  });
+  const port = await listen(server);
+  try {
+    const result = await checkDeployStatus(`http://127.0.0.1:${port}/`);
+    assert.equal(result.kind, 'pending');
+    assert.equal(result.kind === 'pending' && result.state, 'building');
+  } finally {
+    server.close();
+  }
+});
+
+test('checkDeployStatus reports unavailable on a non-ok response', async () => {
+  const server = http.createServer((_req, res) => {
+    res.writeHead(500, { 'content-type': 'text/plain' });
+    res.end('boom');
+  });
+  const port = await listen(server);
+  try {
+    const result = await checkDeployStatus(`http://127.0.0.1:${port}/`);
+    assert.equal(result.kind, 'unavailable');
+  } finally {
+    server.close();
+  }
+});

--- a/src/tools/deploy-tools/deploy-watch.ts
+++ b/src/tools/deploy-tools/deploy-watch.ts
@@ -1,0 +1,36 @@
+/**
+ * Poll a single deploy-status check for the CLI deploy watcher (`--proxy-path`
+ * mode in netlify-mcp.ts).
+ *
+ * This intentionally NEVER throws: the watcher runs it from a bare
+ * `setInterval(async …)` with no surrounding boundary, so a rejected `fetch()`
+ * or a non-JSON body from `.json()` would otherwise become an unhandled
+ * rejection and terminate the process mid-deploy. Transient failures are
+ * returned as a `poll-error` result so the caller can log and keep polling.
+ */
+export type DeployStatusResult =
+  | { kind: 'ready'; deploy: any }
+  | { kind: 'error' }
+  | { kind: 'pending'; state: string }
+  | { kind: 'unavailable'; statusText: string }
+  | { kind: 'poll-error'; message: string };
+
+export async function checkDeployStatus(deployEndpoint: string): Promise<DeployStatusResult> {
+  try {
+    const deployLookup = await fetch(deployEndpoint);
+    if (!deployLookup.ok) {
+      return { kind: 'unavailable', statusText: deployLookup.statusText };
+    }
+
+    const deploy = await deployLookup.json();
+    if (deploy.state === 'ready') {
+      return { kind: 'ready', deploy };
+    }
+    if (deploy.state === 'error') {
+      return { kind: 'error' };
+    }
+    return { kind: 'pending', state: deploy.state };
+  } catch (error) {
+    return { kind: 'poll-error', message: error instanceof Error ? error.message : String(error) };
+  }
+}

--- a/src/utils/api-networking.ts
+++ b/src/utils/api-networking.ts
@@ -219,7 +219,15 @@ export const getAPIJSONResult = async (urlOrPath: string, options: RequestInit =
       throw new Error(`Failed to fetch API: ${response.status}`);
     }
 
-    const data = await response.text();
+    // Reading the body can reject if the connection drops mid-download
+    // (UND_ERR_BODY_TIMEOUT / UND_ERR_SOCKET / UND_ERR_ABORTED). Surface a
+    // clear message instead of leaking the raw undici error.
+    let data: string;
+    try {
+      data = await response.text();
+    } catch (err) {
+      throw new Error(`Failed to read Netlify API response body: ${err instanceof Error ? err.message : String(err)}`);
+    }
     if (!data) {
       return '';
     }
@@ -259,7 +267,12 @@ export const getAPIJSONResult = async (urlOrPath: string, options: RequestInit =
       throw new Error(`Failed to fetch API: ${response.status}`);
     }
 
-    const resultRaw = await response.text();
+    let resultRaw: string;
+    try {
+      resultRaw = await response.text();
+    } catch (err) {
+      throw new Error(`Failed to read Netlify API response body: ${err instanceof Error ? err.message : String(err)}`);
+    }
 
     if (!resultRaw) {
       break;


### PR DESCRIPTION
While auditing error-handling coverage I found two spots on **live code paths** where a `fetch` response is handled in a way that can crash or degrade a deploy. Both are fixed here, and the crash fix ships with regression tests. No dependency changes, no public-API changes.

### 1. Deploy-status watcher can crash the process mid-deploy (`netlify-mcp.ts`)

The CLI deploy watcher (`--proxy-path` mode — spawned on every deploy via the command in `deploy-tools/deploy-site.ts`) polled deploy status from a bare `setInterval(async () => …)` with no surrounding boundary. A rejected `fetch()` (transient network blip) or a non-JSON body from `.json()` becomes an **unhandled promise rejection**, which terminates the watcher process mid-deploy on modern Node.

I confirmed this at runtime — the original pattern exits with code 1 on a transient poll failure:

```
TypeError: fetch failed
    at async Timeout._onTimeout (…/crash-original.mjs)
Node.js v25.2.1
exit code: 1        # "watcher survived" never prints
```

Fix: extract the poll into `checkDeployStatus()`, which **never throws** — transient failures return `{ kind: 'poll-error' }` so the caller logs and keeps polling. Existing behavior (ready → exit 0, error → exit 1, non-ok → exit 0, pending → log & continue) is preserved exactly. Added `node:test` coverage for the unreachable-endpoint, non-JSON-body, ready, pending, and non-ok cases.

### 2. Unguarded `response.text()` in the shared API helper (`src/utils/api-networking.ts`)

`getAPIJSONResult` is the helper behind ~15 read/write tools (users, teams, projects, deploys, env vars, forms…). Its two `response.text()` reads can reject mid-download (`UND_ERR_BODY_TIMEOUT` / `UND_ERR_SOCKET` / `UND_ERR_ABORTED`) if the connection drops after headers arrive. Wrapped both so callers get a clear "failed to read response body" message instead of a raw undici error leaking out — matching the `JSON.parse` guard already present just below.

### Verification
- `npx tsc --noEmit` — clean
- `npm run build` — succeeds
- `npm test` — **43/43 pass** (5 new)

### Scope notes
Kept intentionally tight to reachable code. Two things I deliberately left out:
- The `archiver` usage in `deploy-site.ts` already handles errors via `archive.on('error', reject)` plus a caller-side `try/catch`, so it's untouched.
- `callExtensionAPI` in `extension-tools/extension-utils.ts` parses its body before checking `res.ok`, but that function is currently unreferenced, so I left it out of this PR to keep the change focused on live paths. Happy to include it (or open a follow-up) if you'd like.
