### PR TITLE
fix: cut the top 3 MCP error sources (crashes + misclassified expected outcomes)

### DIFF
--- a/netlify/edge-functions/proxy.ts
+++ b/netlify/edge-functions/proxy.ts
@@ -77,7 +77,10 @@ export async function handleProxy(req: Request, token: string): Promise<Response
     });
 
     if (!isAllowed) {
-      log.error('Unauthorized access attempt to path', { normalizedPath, apisAllowed: decryptedToken.apisAllowed });
+      // Expected access-control enforcement (the token requested a path outside
+      // its scope), not a server error — warn so it stays a security signal
+      // without inflating error metrics.
+      log.warn('proxy denied out-of-scope path', { normalizedPath, apisAllowed: decryptedToken.apisAllowed });
       return new Response('Forbidden', { status: 403 });
     }
   }

--- a/netlify/functions/mcp-server/process-guards.test.ts
+++ b/netlify/functions/mcp-server/process-guards.test.ts
@@ -1,0 +1,20 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { isTransientNetworkError } from './process-guards.ts';
+
+test('isTransientNetworkError flags detached socket resets / timeouts', () => {
+  assert.equal(isTransientNetworkError(Object.assign(new Error('socket hang up'), { code: 'ECONNRESET' })), true);
+  assert.equal(isTransientNetworkError(new Error('socket hang up')), true); // matched by message alone
+  assert.equal(isTransientNetworkError({ code: 'ETIMEDOUT' }), true);
+  assert.equal(isTransientNetworkError({ code: 'EPIPE' }), true);
+  assert.equal(isTransientNetworkError({ code: 'UND_ERR_SOCKET' }), true);
+  assert.equal(isTransientNetworkError({ cause: { code: 'ECONNRESET' } }), true); // nested undici cause
+});
+
+test('isTransientNetworkError does not flag genuine errors', () => {
+  assert.equal(isTransientNetworkError(new TypeError('cannot read properties of undefined')), false);
+  assert.equal(isTransientNetworkError({ code: 'ERR_INVALID_ARG_TYPE' }), false);
+  assert.equal(isTransientNetworkError(new Error('Failed to fetch API: 422')), false);
+  assert.equal(isTransientNetworkError(undefined), false);
+  assert.equal(isTransientNetworkError(null), false);
+});

--- a/netlify/functions/mcp-server/process-guards.ts
+++ b/netlify/functions/mcp-server/process-guards.ts
@@ -1,0 +1,97 @@
+// Resilience against detached, benign network transients.
+//
+// Our top error by volume is a `socket hang up` (ECONNRESET) surfaced as an
+// "Invoke Error" / "Unhandled Promise Rejection" — a keep-alive socket some
+// background HTTP call reused after the peer had already closed it. The stack is
+// `node:_http_client` (the legacy http module), which none of our code uses, so
+// it comes from a dependency's fire-and-forget request and isn't tied to any live
+// request. On Lambda an unhandled one becomes an opaque invocation failure.
+//
+// A reset socket doesn't corrupt process state, so we take over the process-level
+// handlers: log these transients and swallow them (the function keeps serving),
+// while genuine errors are still logged and — for uncaught exceptions, which DO
+// leave the process in an undefined state — re-raised so the sandbox recycles.
+
+import { log } from './logger.ts';
+
+const TRANSIENT_CODES = new Set([
+  'ECONNRESET',
+  'ETIMEDOUT',
+  'EPIPE',
+  'ECONNREFUSED',
+  'EHOSTUNREACH',
+  'ENETUNREACH',
+  'UND_ERR_SOCKET',
+  'UND_ERR_CONNECT_TIMEOUT',
+  'UND_ERR_HEADERS_TIMEOUT',
+  'UND_ERR_BODY_TIMEOUT',
+]);
+
+export function isTransientNetworkError(err: unknown): boolean {
+  const anyErr = err as { code?: unknown; cause?: { code?: unknown }; message?: unknown } | null;
+  const code = anyErr?.code ?? anyErr?.cause?.code;
+  if (typeof code === 'string' && TRANSIENT_CODES.has(code)) {
+    return true;
+  }
+  const message = String(anyErr?.message ?? err ?? '');
+  return /socket hang up/i.test(message);
+}
+
+function fields(err: unknown) {
+  const anyErr = err as { code?: unknown; cause?: { code?: unknown }; message?: unknown } | null;
+  return { code: anyErr?.code ?? anyErr?.cause?.code, message: anyErr?.message };
+}
+
+let installed = false;
+
+export function installProcessGuards(): void {
+  if (installed) return;
+  installed = true;
+
+  // Runs at cold-start module load and only touches process-level handlers, which
+  // are a resilience optimization — not core behavior. So it's best-effort: don't
+  // assume `process` exists (e.g. a non-Node runtime), and never let a failure
+  // installing the handlers break function startup. Degrade to a no-op.
+  try {
+    if (typeof process === 'undefined' || typeof process.on !== 'function') {
+      return;
+    }
+
+    // Own unhandledRejection so a detached transient (see above) doesn't fail the
+    // invocation. Non-transient rejections are logged at error but not re-thrown —
+    // an unhandled rejection doesn't corrupt process state, and crashing the whole
+    // warm container for one stray promise is worse than logging and continuing.
+    process.removeAllListeners('unhandledRejection');
+    process.on('unhandledRejection', (reason: unknown) => {
+      try {
+        if (isTransientNetworkError(reason)) {
+          log.warn('transient network rejection swallowed', fields(reason));
+          return;
+        }
+        log.error('unhandled rejection', { err: reason });
+      } catch {
+        // A rejection handler must never throw — that would become an uncaught
+        // exception and defeat the purpose.
+      }
+    });
+
+    // Own uncaughtException likewise, but re-raise non-transient ones: an uncaught
+    // exception can leave the process in an undefined state, so let the platform
+    // recycle the sandbox.
+    process.removeAllListeners('uncaughtException');
+    process.on('uncaughtException', (err: unknown) => {
+      try {
+        if (isTransientNetworkError(err)) {
+          log.warn('transient network exception swallowed', fields(err));
+          return;
+        }
+        log.error('uncaught exception', { err });
+      } catch {
+        // fall through to re-raise
+      }
+      throw err;
+    });
+  } catch {
+    // Installing the guards is best-effort; a failure here must not break startup.
+  }
+}

--- a/netlify/functions/mcp.ts
+++ b/netlify/functions/mcp.ts
@@ -16,11 +16,16 @@ import { maskToken, paramsSummary } from "./mcp-server/logging.ts";
 import { log, withLogContext, addLogContext, getRequestId, initLogger, getDeployId } from "./mcp-server/logger.ts";
 import { withRequestSignals, getAuthChallenge } from "./mcp-server/request-signals.ts";
 import { systemLogForwarder } from "./mcp-server/system-log-forwarder.ts";
+import { installProcessGuards } from "./mcp-server/process-guards.ts";
 import {Config, Context} from "@netlify/functions";
 
 // Route structured logs onto Netlify's system-log channel for this Node
 // function. Runs once at cold start; edge/CLI keep the default console forwarder.
 initLogger({ forward: systemLogForwarder });
+
+// Keep detached transient network errors (background keep-alive socket resets)
+// from crashing the function as opaque "Invoke Error"s. Runs once at cold start.
+installProcessGuards();
 
 // Netlify serverless function handler
 export default async (req: Request, context: Context) => {

--- a/netlify/functions/oauth-server.ts
+++ b/netlify/functions/oauth-server.ts
@@ -6,10 +6,15 @@ import { addCommonHeadersToHandlerResp, headersToHeadersObject, getParsedUrl } f
 import { safeBodySummary } from "./mcp-server/logging.ts";
 import { log, withLogContext, getRequestId, initLogger, getDeployId } from "./mcp-server/logger.ts";
 import { systemLogForwarder } from "./mcp-server/system-log-forwarder.ts";
+import { installProcessGuards } from "./mcp-server/process-guards.ts";
 
 // Route structured logs onto Netlify's system-log channel for this Node
 // function. Runs once at cold start; edge/CLI keep the default console forwarder.
 initLogger({ forward: systemLogForwarder });
+
+// Keep detached transient network errors (background keep-alive socket resets)
+// from crashing the function as opaque "Invoke Error"s. Runs once at cold start.
+installProcessGuards();
 
 /**
  * Plain OAuth 2.1 Authorization Server for MCP.

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -29,7 +29,7 @@ import { teamDomainTools } from './team-tools/index.js';
 import { projectDomainTools } from './project-tools/index.js';
 import { extensionDomainTools } from './extension-tools/index.js';
 import { checkCompatibility } from '../utils/compatibility.js';
-import { getNetlifyAccessToken, NetlifyUnauthError } from '../utils/api-networking.js';
+import { getNetlifyAccessToken, NetlifyUnauthError, NetlifyApiError } from '../utils/api-networking.js';
 import { appendToLog } from '../utils/logging.js';
 import { log } from '../../netlify/functions/mcp-server/logger.js';
 import { categorizeToolsByReadWrite } from './tool-utils.js';
@@ -131,12 +131,16 @@ const registerDomainTools = (
           result = await tool.cb(args[0], {request: remoteMCPRequest, isRemoteMCP: !!remoteMCPRequest});
         } catch (err) {
           // A mid-operation 401 (NetlifyUnauthError) is a re-auth signal handled
-          // upstream as an OAuth challenge — not an operation failure, so don't
-          // record it as one. Everything else is a genuine failure: log it at
-          // error level so it's attributable to this domain/operation in tracking,
-          // then rethrow so the client still gets its error result.
+          // upstream as an OAuth challenge — not a failure. An API 4xx (not-found,
+          // validation) is an expected client outcome, so log it at warn; only
+          // genuine 5xx/unexpected failures are logged at error. Rethrow either way
+          // so the client still gets its error result.
           if (err instanceof NetlifyUnauthError) throw err;
-          log.error('tool operation failed', { domain, operation: tool.operation, toolName, err });
+          if (err instanceof NetlifyApiError && err.status < 500) {
+            log.warn('tool operation client error', { domain, operation: tool.operation, toolName, status: err.status });
+          } else {
+            log.error('tool operation failed', { domain, operation: tool.operation, toolName, err });
+          }
           throw err;
         }
 
@@ -205,12 +209,16 @@ const registerDomainTools = (
         result = await subtool.cb(selectedSchema.params || {}, {request: remoteMCPRequest, isRemoteMCP: !!remoteMCPRequest});
       } catch (err) {
         // A mid-operation 401 (NetlifyUnauthError) is a re-auth signal handled
-        // upstream as an OAuth challenge — not an operation failure, so don't
-        // record it as one. Everything else is a genuine failure: log it at
-        // error level so it's attributable to this domain/operation in tracking,
-        // then rethrow so the client still gets its error result.
+        // upstream as an OAuth challenge — not a failure. An API 4xx (not-found,
+        // validation) is an expected client outcome, so log it at warn; only
+        // genuine 5xx/unexpected failures are logged at error. Rethrow either way
+        // so the client still gets its error result.
         if (err instanceof NetlifyUnauthError) throw err;
-        log.error('tool operation failed', { domain, operation, toolName, err });
+        if (err instanceof NetlifyApiError && err.status < 500) {
+          log.warn('tool operation client error', { domain, operation, toolName, status: err.status });
+        } else {
+          log.error('tool operation failed', { domain, operation, toolName, err });
+        }
         throw err;
       }
 

--- a/src/utils/api-networking.ts
+++ b/src/utils/api-networking.ts
@@ -29,6 +29,19 @@ export class NetlifyUnauthError extends Error {
   }
 }
 
+// Thrown when the Netlify API returns a non-OK status. Carries the status so
+// callers can tell an expected client outcome (4xx: not-found, validation) apart
+// from a genuine server/network failure (5xx), and log at the right severity.
+// The message is unchanged (`Failed to fetch API: <status>`) for compatibility.
+export class NetlifyApiError extends Error {
+  readonly status: number;
+  constructor(status: number) {
+    super(`Failed to fetch API: ${status}`);
+    this.name = 'NetlifyApiError';
+    this.status = status;
+  }
+}
+
 const readTokenFromEnv = async () => {
   try {
     // Netlify CLI uses envPaths(...) to build the file path for config.json.
@@ -216,7 +229,7 @@ export const getAPIJSONResult = async (urlOrPath: string, options: RequestInit =
       if(apiInteractionOptions.failureCallback){
         return apiInteractionOptions.failureCallback(response);
       }
-      throw new Error(`Failed to fetch API: ${response.status}`);
+      throw new NetlifyApiError(response.status);
     }
 
     // Reading the body can reject if the connection drops mid-download
@@ -264,7 +277,7 @@ export const getAPIJSONResult = async (urlOrPath: string, options: RequestInit =
       if (apiInteractionOptions.failureCallback) {
         return apiInteractionOptions.failureCallback(response);
       }
-      throw new Error(`Failed to fetch API: ${response.status}`);
+      throw new NetlifyApiError(response.status);
     }
 
     let resultRaw: string;


### PR DESCRIPTION


Reviewed the top errors on the Netlify AX dashboard and addressed the three highest-volume sources.

1. socket hang up crashes (~4,314/7d, #1) — detached ECONNRESET on a background keep-alive socket (node:_http_client, from a dependency, not our undici fetch) surfaced as an opaque 'Invoke Error'/'Unhandled Promise Rejection' that fails the invocation. Add process-guards.ts: own unhandledRejection/uncaughtException, log+swallow known transient network errors, re-raise genuine uncaught ones. Installed once at cold start in mcp.ts and oauth-server.ts.

2. 'tool operation failed' on expected API 4xx (404 not-found, 422 validation) — these are normal client outcomes, not server errors. Add NetlifyApiError carrying the status; the tool-dispatch catch logs 4xx at warn ('tool operation client error') and reserves error for 5xx/unexpected.

3. proxy 'Unauthorized access attempt to path' (402/7d) — the proxy correctly denying an out-of-scope path is expected access control, not a server error; reclassify to warn ('proxy denied out-of-scope path').

Net: real crashes stop being fatal, and the error dashboard reflects genuine failures instead of expected 4xx/access-control/transient noise. Warnings retain the signal. 67/67 tests pass (2 new for the transient classifier); typecheck clean.