### PR TITLE
fix(build): move proxy test out of edge-functions dir (unbreaks prod build)

### DIFF
--- a/netlify/functions/mcp-server/proxy.test.ts
+++ b/netlify/functions/mcp-server/proxy.test.ts
@@ -1,7 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { handleProxy } from './proxy.ts';
-import { createJWE } from '../functions/mcp-server/utils.ts';
+import { handleProxy } from '../../edge-functions/proxy.ts';
+import { createJWE } from './utils.ts';
 
 // createJWE/decryptJWE round-trip on the localhost dev key when JWE_SECRET and
 // OAUTH_ISSUER are unset (the test environment), so no secret setup is needed.


### PR DESCRIPTION
## Problem
Prod build fails:
```
Default export in '.../netlify/edge-functions/proxy.test.ts' must be a function.
```
Netlify treats **every top-level file in `netlify/edge-functions/`** as an edge function. `proxy.test.ts` (added in the security PR #28) has no default export, so it fails the build.

## Fix
Move `proxy.test.ts` → `netlify/functions/mcp-server/proxy.test.ts` — the shared-code subdir where all other `*.test.ts` already live and build fine — and fix its two relative imports. The test is unchanged; `edge-functions/` now contains only real edge functions (`proxy.ts`, `request-logger.ts`).

## Verify
- `node --test` — proxy tests 3/3, full suite 67/67
- `netlify/edge-functions/` has no `.test.ts` files

🤖 Generated with [Claude Code](https://claude.com/claude-code)