### PR TITLE
fix: eliminate 'socket hang up' uncaught exceptions at the request source

### DIFF
--- a/netlify/functions/mcp-server/http-guard.test.ts
+++ b/netlify/functions/mcp-server/http-guard.test.ts
@@ -1,0 +1,20 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import https from 'node:https';
+import './http-guard.ts'; // self-installs the patch on import
+
+// The guard exists so a socket 'error' (ECONNRESET / "socket hang up") on a
+// fire-and-forget request can't become an uncaughtException. We assert the guard
+// attaches a default 'error' listener to every outbound request.
+for (const [name, mod] of [['http', http], ['https', https]] as const) {
+  for (const method of ['request', 'get'] as const) {
+    test(`${name}.${method} outbound requests get a default error listener`, () => {
+      // Port 1 refuses the connection; we only inspect the listener, then clean up.
+      const req = (mod as typeof http)[method](`${name}://127.0.0.1:1/`);
+      assert.ok(req.listenerCount('error') >= 1, `${name}.${method} should have an error listener`);
+      req.on('error', () => {}); // handle the (expected) connection failure in-test
+      req.destroy();
+    });
+  }
+}

--- a/netlify/functions/mcp-server/http-guard.ts
+++ b/netlify/functions/mcp-server/http-guard.ts
@@ -1,0 +1,53 @@
+// Attach a default 'error' listener to every outbound Node http/https request.
+//
+// Our top error is a detached `socket hang up` (ECONNRESET) on a legacy-`http`
+// request (stack bottoms out at node:_http_client) made by a dependency that
+// never handles the socket's 'error' event — so it surfaces as an uncaughtException
+// the platform logs as an opaque "Invoke Error". A process-level uncaughtException
+// handler can't reliably suppress that on Lambda (the runtime reports it itself),
+// but handling the 'error' at the request means it never becomes uncaught in the
+// first place. If the caller adds its own 'error' listener too, both fire (harmless).
+//
+// This self-installs on import and MUST be imported FIRST in a function entrypoint
+// (before any dependency that makes http calls), so the patch is in place before
+// anything captures a reference to http.request/get. Node-only — never edge/Deno.
+
+import http from 'node:http';
+import https from 'node:https';
+import { log } from './logger.ts';
+import { isTransientNetworkError } from './process-guards.ts';
+
+function attachErrorListener(req: unknown): unknown {
+  try {
+    (req as { on?: (e: string, cb: (err: unknown) => void) => void })?.on?.('error', (err: unknown) => {
+      // Transient resets (ECONNRESET / "socket hang up") are expected background
+      // noise and swallowed silently; anything else is worth a warn.
+      if (!isTransientNetworkError(err)) {
+        const anyErr = err as { code?: unknown; message?: unknown } | null;
+        log.warn('outbound http request error', { code: anyErr?.code, message: anyErr?.message });
+      }
+    });
+  } catch {
+    // Instrumentation must never break a request.
+  }
+  return req;
+}
+
+function install(): void {
+  try {
+    if (typeof process === 'undefined') return;
+    for (const mod of [http, https]) {
+      for (const method of ['request', 'get'] as const) {
+        const original = (mod as Record<string, unknown>)[method];
+        if (typeof original !== 'function') continue;
+        (mod as Record<string, unknown>)[method] = function patched(this: unknown, ...args: unknown[]) {
+          return attachErrorListener((original as (...a: unknown[]) => unknown).apply(this, args));
+        };
+      }
+    }
+  } catch {
+    // Best-effort; a failure here must not break function startup.
+  }
+}
+
+install();

--- a/netlify/functions/mcp-server/process-guards.ts
+++ b/netlify/functions/mcp-server/process-guards.ts
@@ -65,7 +65,9 @@ export function installProcessGuards(): void {
     process.on('unhandledRejection', (reason: unknown) => {
       try {
         if (isTransientNetworkError(reason)) {
-          log.warn('transient network rejection swallowed', fields(reason));
+          // High-volume, unactionable background resets — debug so they don't
+          // flood steady-state logs (the http-guard handles most at the request).
+          log.debug('transient network rejection swallowed', fields(reason));
           return;
         }
         log.error('unhandled rejection', { err: reason });
@@ -82,7 +84,7 @@ export function installProcessGuards(): void {
     process.on('uncaughtException', (err: unknown) => {
       try {
         if (isTransientNetworkError(err)) {
-          log.warn('transient network exception swallowed', fields(err));
+          log.debug('transient network exception swallowed', fields(err));
           return;
         }
         log.error('uncaught exception', { err });

--- a/netlify/functions/mcp.ts
+++ b/netlify/functions/mcp.ts
@@ -2,6 +2,10 @@
 // createMcpHandler serves BOTH 2026-07-28 (modern) and 2025-era (legacy) traffic
 // from one web-standard (Request)=>Response handler — replacing v1's
 // StreamableHTTPServerTransport + fetch-to-node bridge.
+
+// FIRST import on purpose: self-installs an outbound-http error guard before any
+// dependency that makes http calls loads (see mcp-server/http-guard.ts).
+import "./mcp-server/http-guard.ts";
 import { createMcpHandler, McpServer } from "@modelcontextprotocol/server";
 import { z } from "zod";
 import { addCORSHeadersToFetchResp, returnNeedsAuthResponse } from "./mcp-server/utils.ts";

--- a/netlify/functions/oauth-server.ts
+++ b/netlify/functions/oauth-server.ts
@@ -1,3 +1,6 @@
+// FIRST import on purpose: self-installs an outbound-http error guard before any
+// dependency that makes http calls loads (see mcp-server/http-guard.ts).
+import "./mcp-server/http-guard.ts";
 import type { Handler, HandlerResponse } from "@netlify/functions";
 import { handleAuthStart, handleClientRegistration, handleClientSideAuthExchange, handleCodeExchange, handleServerSideAuthRedirect } from "./mcp-server/auth-flow.ts";
 import { buildAuthServerMetadata, buildProtectedResourceMetadata } from "./mcp-server/metadata.ts";


### PR DESCRIPTION
## Problem
After PR #29, `socket hang up` **errors** persist on the dashboard (~2k/hr). Diagnosis from Datadog:
- The process-guards *are* live and catching the **promise-based** resets — 17,789 `transient network rejection swallowed` in 2 days.
- But the persisting errors are `Invoke Error socket hang up` — an **uncaughtException** from a socket `'error'` on a **legacy-`http`** request (`node:_http_client`). The Lambda/Netlify runtime logs that itself, independent of our process `uncaughtException` handler, so the handler can't suppress it (the platform-override fragility we flagged).

## Fix
`http-guard.ts` patches `http`/`https` `.request`/`.get` to attach a default `'error'` listener to every outbound request → a socket reset is handled and **never becomes uncaught**. Self-installs on import; imported **first** in `mcp.ts`/`oauth-server.ts` so it's in place before any dependency captures a reference. Node-only.

Also: dropped the process-guard swallow logs `warn`→`debug` (they were ~17k/2d of unactionable noise now that the guard handles most at the request).

## Verify
- 71/71 tests pass (4 new for the guard), typecheck clean.
- Post-deploy: confirm `Invoke Error socket hang up` count drops.

## Note
Some of these logs have a blank `function_name`; if any originate in the platform's *own* outbound calls (not our deps), the guard won't reach those — those would need a dashboard exclusion / a note to Netlify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)