### PR TITLE
Add context-cost badge (2,831 tokens, reproducibly measured)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Netlify MCP Server
 
+[![context cost](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fathakur3%2Fmcp-context-cost%2Fmain%2Fbadges%2Fnetlify.json)](https://athakur3.github.io/mcp-context-cost/METHODOLOGY)
+
 [Netlify MCP Server](https://docs.netlify.com/welcome/build-with-ai/netlify-mcp-server/) follows the [Model Context Protocol (MCP)](https://modelcontextprotocol.org) to enable code agents to use the Netlify API and CLI—so they can create new projects, build, deploy, and manage your Netlify resources using natural language prompts.
 
 ---


### PR DESCRIPTION
One line: a shields.io badge showing what netlify-mcp's tool schemas cost in context tokens — currently **2,831 tokens across 9 tools** (largest: `netlify-project-services-updater` at 896), measured 2026-08-16. Right at the median of the 57 popular MCP servers we measured (2,636).

The badge JSON lives in [our repo](https://github.com/athakur3/mcp-context-cost) and refreshes weekly; the number links to a reproducible methodology — raw `tools/list` capture + pinned `o200k_base` tokenizer, re-derivable in five lines from [results/netlify/measurement.json](https://github.com/athakur3/mcp-context-cost/blob/main/results/netlify/measurement.json).

If you'd rather not carry this, close freely — no hard feelings. To own the number in your own CI instead: sd2k/mcp-tokens-action (badge support proposed in sd2k/mcp-tokens-action#5).