### PR TITLE
feat(oauth): log client_name at registration (EX-3039)

### DIFF
--- a/netlify/edge-functions/proxy.ts
+++ b/netlify/edge-functions/proxy.ts
@@ -1,5 +1,5 @@
 import { decryptJWE } from "../functions/mcp-server/utils.ts";
-import { log, withLogContext, addLogContext, getRequestId, getDeployId } from "../functions/mcp-server/logger.ts";
+import { log, withLogContext, addLogContext, getRequestId, getDeployId, truncateForLog } from "../functions/mcp-server/logger.ts";
 import type {Config, Context} from '@netlify/edge-functions';
 
 // Escape regex metacharacters so an allowed-path template is matched literally
@@ -21,7 +21,7 @@ export default async (req: Request, ctx: Context) => {
       requestId: getRequestId(req.headers),
       deployId: getDeployId(req.headers),
       httpMethod: req.method,
-      userAgent: req.headers.get('user-agent') ?? undefined,
+      userAgent: truncateForLog(req.headers.get('user-agent')),
     },
     () => handleProxy(req, token),
   );

--- a/netlify/edge-functions/request-logger.ts
+++ b/netlify/edge-functions/request-logger.ts
@@ -40,7 +40,7 @@ export default async (request: Request, context: Context) => {
       requestId: getRequestId(request.headers),
       deployId: getDeployId(request.headers),
       httpMethod: request.method,
-      path,
+      path: truncateForLog(path),
       userAgent: truncateForLog(request.headers.get('user-agent')),
     },
     async () => {

--- a/netlify/edge-functions/request-logger.ts
+++ b/netlify/edge-functions/request-logger.ts
@@ -1,6 +1,6 @@
 import type { Context } from '@netlify/edge-functions';
 import { isVerboseLogging, maskToken, safeBodySummary, mcpBodySummary } from '../functions/mcp-server/logging.ts';
-import { log, withLogContext, getRequestId, getDeployId } from '../functions/mcp-server/logger.ts';
+import { log, withLogContext, getRequestId, getDeployId, truncateForLog } from '../functions/mcp-server/logger.ts';
 
 // Catch-all request/response logger. Runs in front of every request (declared
 // first in netlify.toml so it wraps the proxy edge function and all regular
@@ -41,7 +41,7 @@ export default async (request: Request, context: Context) => {
       deployId: getDeployId(request.headers),
       httpMethod: request.method,
       path,
-      userAgent: request.headers.get('user-agent') ?? undefined,
+      userAgent: truncateForLog(request.headers.get('user-agent')),
     },
     async () => {
       // Read the request body via a clone so the original is left intact for

--- a/netlify/functions/mcp-server/auth-flow.test.ts
+++ b/netlify/functions/mcp-server/auth-flow.test.ts
@@ -86,3 +86,16 @@ test('register: logged redirect_uris are bounded in count and length, but the re
   assert.equal(response.statusCode, 201);
   assert.equal(JSON.parse(response.body).redirect_uris.length, 15);
 });
+
+test('register: logged scope is truncated to 200 characters', async () => {
+  const repeatedScope = Array.from({ length: 500 }, () => SUPPORTED_SCOPES[0]).join(' ');
+  const { response, parsed } = await captureRegisterLog({
+    redirect_uris: ['http://127.0.0.1:1234/cb'],
+    scope: repeatedScope,
+  });
+
+  assert.ok(parsed);
+  assert.equal(parsed.scope.length, 200);
+
+  assert.equal(response.statusCode, 201);
+});

--- a/netlify/functions/mcp-server/auth-flow.test.ts
+++ b/netlify/functions/mcp-server/auth-flow.test.ts
@@ -69,3 +69,20 @@ test('register: omits client_name from the log line when the client sends none',
   assert.ok(parsed);
   assert.equal('client_name' in parsed, false);
 });
+
+test('register: logged redirect_uris are bounded in count and length, but the response is not', async () => {
+  const longRedirectUris = Array.from(
+    { length: 15 },
+    (_, i) => `http://127.0.0.1:1234/${'x'.repeat(200)}-${i}`,
+  );
+  const { response, parsed } = await captureRegisterLog({
+    redirect_uris: longRedirectUris,
+  });
+
+  assert.ok(parsed);
+  assert.equal(parsed.redirect_uris.length, 10);
+  assert.ok(parsed.redirect_uris.every((uri: string) => uri.length === 200));
+
+  assert.equal(response.statusCode, 201);
+  assert.equal(JSON.parse(response.body).redirect_uris.length, 15);
+});

--- a/netlify/functions/mcp-server/auth-flow.test.ts
+++ b/netlify/functions/mcp-server/auth-flow.test.ts
@@ -1,0 +1,71 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { handleClientRegistration } from './auth-flow.ts';
+import { SUPPORTED_SCOPES } from './oauth-config.ts';
+
+// These tests run against the localhost dev key (no OAUTH_ISSUER / JWE_SECRET
+// set), which is exactly the stateless round-trip we depend on in production.
+// register: issued stateless client_id is logged at info, which is not gated
+// by MCP_VERBOSE_LOGGING, so no env setup is needed to observe it.
+
+const REGISTER_LOG_MESSAGE = 'register: issued stateless client_id';
+
+function makeRequest(body: Record<string, unknown>): Request {
+  return new Request('http://localhost/register', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+}
+
+async function captureRegisterLog(body: Record<string, unknown>) {
+  const lines: string[] = [];
+  const origLog = console.log;
+  console.log = (line: string) => {
+    lines.push(line);
+  };
+  let response: any;
+  try {
+    response = await handleClientRegistration(makeRequest(body), SUPPORTED_SCOPES);
+  } finally {
+    console.log = origLog;
+  }
+
+  const parsed = lines
+    .map((line) => JSON.parse(line))
+    .find((entry) => entry.message === REGISTER_LOG_MESSAGE);
+
+  return { response, parsed };
+}
+
+test('register: logs client_name at info when the client sends one', async () => {
+  const { response, parsed } = await captureRegisterLog({
+    redirect_uris: ['http://127.0.0.1:1234/cb'],
+    client_name: 'Claude Code',
+  });
+
+  assert.equal(response.statusCode, 201);
+  assert.ok(parsed);
+  assert.equal(parsed.level, 'info');
+  assert.equal(parsed.client_name, 'Claude Code');
+});
+
+test('register: logged client_name is truncated to 200 characters', async () => {
+  const longName = 'x'.repeat(300);
+  const { parsed } = await captureRegisterLog({
+    redirect_uris: ['http://127.0.0.1:1234/cb'],
+    client_name: longName,
+  });
+
+  assert.ok(parsed);
+  assert.equal(parsed.client_name.length, 200);
+});
+
+test('register: omits client_name from the log line when the client sends none', async () => {
+  const { parsed } = await captureRegisterLog({
+    redirect_uris: ['http://127.0.0.1:1234/cb'],
+  });
+
+  assert.ok(parsed);
+  assert.equal('client_name' in parsed, false);
+});

--- a/netlify/functions/mcp-server/auth-flow.test.ts
+++ b/netlify/functions/mcp-server/auth-flow.test.ts
@@ -5,6 +5,10 @@ import { handleClientRegistration } from './auth-flow.ts';
 import { resolveClient } from './client-registry.ts';
 import { SUPPORTED_SCOPES } from './oauth-config.ts';
 
+// These tests round-trip createJWE/decryptJWE on the localhost dev key, which
+// requires JWE_SECRET to be unset regardless of what the ambient shell env has.
+delete process.env.JWE_SECRET;
+
 // register: issued stateless client_id is logged at info, which is not gated
 // by MCP_VERBOSE_LOGGING, so no env setup is needed to observe it.
 
@@ -82,21 +86,18 @@ test('register: omits client_name from the log line when the client sends none',
 });
 
 test('register: logged redirect_hosts are bounded and never leak uri secrets, but the response is not', async () => {
+  const loopbackUri = 'http://127.0.0.1:4321/cb';
   const taggedUris = Array.from(
     { length: 15 },
     (_, i) => `https://user:pw@example.com/cb?email=a@b.c&token=secret-marker#frag-${i}`,
   );
-  const loopbackUri = 'http://127.0.0.1:4321/cb';
-  const redirectUris = [...taggedUris, loopbackUri];
+  const redirectUris = [loopbackUri, ...taggedUris];
 
   const { response, parsed, rawLine } = await captureRegisterLog({ redirect_uris: redirectUris });
 
   assert.ok(parsed);
   assert.ok(rawLine);
-  assert.equal(parsed.redirect_hosts.length, 10);
-  assert.ok(
-    parsed.redirect_hosts.every((host: string) => host === 'example.com' || host === '127.0.0.1:4321'),
-  );
+  assert.deepEqual(parsed.redirect_hosts, ['127.0.0.1:4321', ...Array(9).fill('example.com')]);
   assert.ok(!rawLine.includes('secret-marker'));
   assert.ok(!rawLine.includes('user:pw'));
   assert.ok(!rawLine.includes('email='));
@@ -105,6 +106,16 @@ test('register: logged redirect_hosts are bounded and never leak uri secrets, bu
   const responseBody = JSON.parse(response.body);
   assert.equal(responseBody.redirect_uris.length, 16);
   assert.deepEqual(responseBody.redirect_uris, redirectUris);
+});
+
+test('register: logged redirect_hosts are length-bounded for a long host', async () => {
+  const longHostUri = `https://${'a'.repeat(5000)}.com/cb`;
+  const { response, parsed } = await captureRegisterLog({ redirect_uris: [longHostUri] });
+
+  assert.ok(parsed);
+  assert.equal(parsed.redirect_hosts[0].length, 200);
+
+  assert.equal(response.statusCode, 201);
 });
 
 test('register: logged scope is truncated to 200 characters', async () => {

--- a/netlify/functions/mcp-server/auth-flow.test.ts
+++ b/netlify/functions/mcp-server/auth-flow.test.ts
@@ -2,10 +2,9 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 
 import { handleClientRegistration } from './auth-flow.ts';
+import { resolveClient } from './client-registry.ts';
 import { SUPPORTED_SCOPES } from './oauth-config.ts';
 
-// These tests run against the localhost dev key (no OAUTH_ISSUER / JWE_SECRET
-// set), which is exactly the stateless round-trip we depend on in production.
 // register: issued stateless client_id is logged at info, which is not gated
 // by MCP_VERBOSE_LOGGING, so no env setup is needed to observe it.
 
@@ -31,11 +30,16 @@ async function captureRegisterLog(body: Record<string, unknown>) {
     console.log = origLog;
   }
 
-  const parsed = lines
-    .map((line) => JSON.parse(line))
-    .find((entry) => entry.message === REGISTER_LOG_MESSAGE);
+  const rawLine = lines.find((line) => {
+    try {
+      return JSON.parse(line).message === REGISTER_LOG_MESSAGE;
+    } catch {
+      return false;
+    }
+  });
+  const parsed = rawLine ? JSON.parse(rawLine) : undefined;
 
-  return { response, parsed };
+  return { response, parsed, rawLine };
 }
 
 test('register: logs client_name at info when the client sends one', async () => {
@@ -52,13 +56,20 @@ test('register: logs client_name at info when the client sends one', async () =>
 
 test('register: logged client_name is truncated to 200 characters', async () => {
   const longName = 'x'.repeat(300);
-  const { parsed } = await captureRegisterLog({
+  const { response, parsed } = await captureRegisterLog({
     redirect_uris: ['http://127.0.0.1:1234/cb'],
     client_name: longName,
   });
 
   assert.ok(parsed);
   assert.equal(parsed.client_name.length, 200);
+
+  const responseBody = JSON.parse(response.body);
+  assert.equal(responseBody.client_name, longName);
+
+  const { client } = await resolveClient(responseBody.client_id);
+  assert.ok(client);
+  assert.equal(client.client_name, longName);
 });
 
 test('register: omits client_name from the log line when the client sends none', async () => {
@@ -70,21 +81,30 @@ test('register: omits client_name from the log line when the client sends none',
   assert.equal('client_name' in parsed, false);
 });
 
-test('register: logged redirect_uris are bounded in count and length, but the response is not', async () => {
-  const longRedirectUris = Array.from(
+test('register: logged redirect_hosts are bounded and never leak uri secrets, but the response is not', async () => {
+  const taggedUris = Array.from(
     { length: 15 },
-    (_, i) => `http://127.0.0.1:1234/${'x'.repeat(200)}-${i}`,
+    (_, i) => `https://user:pw@example.com/cb?email=a@b.c&token=secret-marker#frag-${i}`,
   );
-  const { response, parsed } = await captureRegisterLog({
-    redirect_uris: longRedirectUris,
-  });
+  const loopbackUri = 'http://127.0.0.1:4321/cb';
+  const redirectUris = [...taggedUris, loopbackUri];
+
+  const { response, parsed, rawLine } = await captureRegisterLog({ redirect_uris: redirectUris });
 
   assert.ok(parsed);
-  assert.equal(parsed.redirect_uris.length, 10);
-  assert.ok(parsed.redirect_uris.every((uri: string) => uri.length === 200));
+  assert.ok(rawLine);
+  assert.equal(parsed.redirect_hosts.length, 10);
+  assert.ok(
+    parsed.redirect_hosts.every((host: string) => host === 'example.com' || host === '127.0.0.1:4321'),
+  );
+  assert.ok(!rawLine.includes('secret-marker'));
+  assert.ok(!rawLine.includes('user:pw'));
+  assert.ok(!rawLine.includes('email='));
 
   assert.equal(response.statusCode, 201);
-  assert.equal(JSON.parse(response.body).redirect_uris.length, 15);
+  const responseBody = JSON.parse(response.body);
+  assert.equal(responseBody.redirect_uris.length, 16);
+  assert.deepEqual(responseBody.redirect_uris, redirectUris);
 });
 
 test('register: logged scope is truncated to 200 characters', async () => {
@@ -98,4 +118,10 @@ test('register: logged scope is truncated to 200 characters', async () => {
   assert.equal(parsed.scope.length, 200);
 
   assert.equal(response.statusCode, 201);
+  const responseBody = JSON.parse(response.body);
+  assert.equal(responseBody.scope, repeatedScope);
+
+  const { client } = await resolveClient(responseBody.client_id);
+  assert.ok(client);
+  assert.equal(client.scope, repeatedScope);
 });

--- a/netlify/functions/mcp-server/auth-flow.test.ts
+++ b/netlify/functions/mcp-server/auth-flow.test.ts
@@ -5,8 +5,9 @@ import { handleClientRegistration } from './auth-flow.ts';
 import { resolveClient } from './client-registry.ts';
 import { SUPPORTED_SCOPES } from './oauth-config.ts';
 
-// These tests round-trip createJWE/decryptJWE on the localhost dev key, which
-// requires JWE_SECRET to be unset regardless of what the ambient shell env has.
+// Pin the dev-key path regardless of ambient env: a localhost issuer with no
+// JWE_SECRET makes createJWE/decryptJWE use the fixed dev-only key.
+process.env.OAUTH_ISSUER = 'http://localhost:8888';
 delete process.env.JWE_SECRET;
 
 // register: issued stateless client_id is logged at info, which is not gated

--- a/netlify/functions/mcp-server/auth-flow.ts
+++ b/netlify/functions/mcp-server/auth-flow.ts
@@ -454,7 +454,17 @@ export async function handleClientRegistration(req: Request, supportedScopes: st
 
   const clientId = await createStatelessClientId(client);
 
-  log.debug('register: issued stateless client_id', { redirect_uris: redirectUris, application_type: applicationType, scope });
+  // Untrusted client input; cap so a hostile registration can't bloat log lines.
+  const MAX_LOGGED_CLIENT_NAME = 200;
+  const loggedClientName =
+    typeof body.client_name === 'string' ? body.client_name.slice(0, MAX_LOGGED_CLIENT_NAME) : undefined;
+
+  log.info('register: issued stateless client_id', {
+    redirect_uris: redirectUris,
+    application_type: applicationType,
+    scope,
+    client_name: loggedClientName,
+  });
 
   // RFC 7591 §3.2.1 success response. client_id_issued_at is informational; the
   // registration never expires (no client_secret_expires_at needed for a public

--- a/netlify/functions/mcp-server/auth-flow.ts
+++ b/netlify/functions/mcp-server/auth-flow.ts
@@ -33,7 +33,7 @@ function rejectUnknownClients(): boolean {
 /** Host of a redirect_uri for logging, without leaking the full URI. */
 function redirectHostForLog(redirectUri: string): string {
   try {
-    return new URL(redirectUri).host || 'unknown';
+    return truncateForLog(new URL(redirectUri).host) || 'unknown';
   } catch {
     return 'unparseable';
   }

--- a/netlify/functions/mcp-server/auth-flow.ts
+++ b/netlify/functions/mcp-server/auth-flow.ts
@@ -371,7 +371,7 @@ export async function handleServerSideAuthRedirect(req: Request): Promise<Handle
 
     // TODO: future, we will add specific tools and other context to this for
     // downstream validation
-    log.info('server redirect: issuing authorization code', { client_id: validatedState.client_id, redirect_uri: validatedState.redirect_uri, scope: validatedState.scope, hasIdentity: !!identity });
+    log.info('server redirect: issuing authorization code', { client_id: maskToken(validatedState.client_id), redirect_host: redirectHostForLog(validatedState.redirect_uri), scope: truncateForLog(validatedState.scope), hasIdentity: !!identity });
 
     const jwe = await createJWE({ state: validatedState, accessToken: token, ...(identity ? { identity } : {}) } satisfies CODE_JWE_PAYLOAD);
 

--- a/netlify/functions/mcp-server/auth-flow.ts
+++ b/netlify/functions/mcp-server/auth-flow.ts
@@ -2,7 +2,7 @@ import type { HandlerResponse } from "@netlify/functions";
 import { createHash } from "crypto";
 import { createJWE, decryptJWE, getOAuthIssuer } from "./utils.ts";
 import { maskToken } from "./logging.ts";
-import { log } from "./logger.ts";
+import { log, truncateForLog } from "./logger.ts";
 import { resolveIdentity, type TokenIdentity } from "./identity.ts";
 import {
   createStatelessClientId,
@@ -454,22 +454,17 @@ export async function handleClientRegistration(req: Request, supportedScopes: st
 
   const clientId = await createStatelessClientId(client);
 
-  // Untrusted client input; cap these fields so a hostile registration can't
-  // bloat log lines.
-  const MAX_LOGGED_FIELD_LENGTH = 200;
+  // client_name, redirect_uris, and scope are client-asserted: nothing verifies
+  // client_name, and a registration can send arbitrarily many/long redirect_uris.
+  // The bounded copies below are for this log line only — the stored client and
+  // the response below carry the full, untouched values.
   const MAX_LOGGED_REDIRECT_URIS = 10;
-  const loggedClientName =
-    typeof body.client_name === 'string' ? body.client_name.slice(0, MAX_LOGGED_FIELD_LENGTH) : undefined;
-  const loggedRedirectUris = redirectUris
-    .slice(0, MAX_LOGGED_REDIRECT_URIS)
-    .map((uri) => uri.slice(0, MAX_LOGGED_FIELD_LENGTH));
-  const loggedScope = scope?.slice(0, MAX_LOGGED_FIELD_LENGTH);
 
   log.info('register: issued stateless client_id', {
-    redirect_uris: loggedRedirectUris,
+    redirect_hosts: redirectUris.slice(0, MAX_LOGGED_REDIRECT_URIS).map(redirectHostForLog),
     application_type: applicationType,
-    scope: loggedScope,
-    client_name: loggedClientName,
+    scope: truncateForLog(scope),
+    client_name: truncateForLog(body.client_name),
   });
 
   // RFC 7591 §3.2.1 success response. client_id_issued_at is informational; the

--- a/netlify/functions/mcp-server/auth-flow.ts
+++ b/netlify/functions/mcp-server/auth-flow.ts
@@ -454,13 +454,18 @@ export async function handleClientRegistration(req: Request, supportedScopes: st
 
   const clientId = await createStatelessClientId(client);
 
-  // Untrusted client input; cap so a hostile registration can't bloat log lines.
-  const MAX_LOGGED_CLIENT_NAME = 200;
+  // Untrusted client input; cap both fields so a hostile registration can't
+  // bloat log lines.
+  const MAX_LOGGED_FIELD_LENGTH = 200;
+  const MAX_LOGGED_REDIRECT_URIS = 10;
   const loggedClientName =
-    typeof body.client_name === 'string' ? body.client_name.slice(0, MAX_LOGGED_CLIENT_NAME) : undefined;
+    typeof body.client_name === 'string' ? body.client_name.slice(0, MAX_LOGGED_FIELD_LENGTH) : undefined;
+  const loggedRedirectUris = redirectUris
+    .slice(0, MAX_LOGGED_REDIRECT_URIS)
+    .map((uri) => uri.slice(0, MAX_LOGGED_FIELD_LENGTH));
 
   log.info('register: issued stateless client_id', {
-    redirect_uris: redirectUris,
+    redirect_uris: loggedRedirectUris,
     application_type: applicationType,
     scope,
     client_name: loggedClientName,

--- a/netlify/functions/mcp-server/auth-flow.ts
+++ b/netlify/functions/mcp-server/auth-flow.ts
@@ -454,7 +454,7 @@ export async function handleClientRegistration(req: Request, supportedScopes: st
 
   const clientId = await createStatelessClientId(client);
 
-  // Untrusted client input; cap both fields so a hostile registration can't
+  // Untrusted client input; cap these fields so a hostile registration can't
   // bloat log lines.
   const MAX_LOGGED_FIELD_LENGTH = 200;
   const MAX_LOGGED_REDIRECT_URIS = 10;
@@ -463,11 +463,12 @@ export async function handleClientRegistration(req: Request, supportedScopes: st
   const loggedRedirectUris = redirectUris
     .slice(0, MAX_LOGGED_REDIRECT_URIS)
     .map((uri) => uri.slice(0, MAX_LOGGED_FIELD_LENGTH));
+  const loggedScope = scope?.slice(0, MAX_LOGGED_FIELD_LENGTH);
 
   log.info('register: issued stateless client_id', {
     redirect_uris: loggedRedirectUris,
     application_type: applicationType,
-    scope,
+    scope: loggedScope,
     client_name: loggedClientName,
   });
 

--- a/netlify/functions/mcp-server/client-registry.test.ts
+++ b/netlify/functions/mcp-server/client-registry.test.ts
@@ -11,6 +11,7 @@ import { staticClients } from './oauth-clients.ts';
 
 // These tests run against the localhost dev key (no OAUTH_ISSUER / JWE_SECRET
 // set), which is exactly the stateless round-trip we depend on in production.
+delete process.env.JWE_SECRET;
 
 test('inferApplicationType: loopback and custom-scheme redirects are native', () => {
   assert.equal(inferApplicationType(['http://localhost:8080/cb']), 'native');

--- a/netlify/functions/mcp-server/client-registry.test.ts
+++ b/netlify/functions/mcp-server/client-registry.test.ts
@@ -9,8 +9,9 @@ import {
 } from './client-registry.ts';
 import { staticClients } from './oauth-clients.ts';
 
-// These tests run against the localhost dev key (no OAUTH_ISSUER / JWE_SECRET
-// set), which is exactly the stateless round-trip we depend on in production.
+// Pin the dev-key path regardless of ambient env: a localhost issuer with no
+// JWE_SECRET makes createJWE/decryptJWE use the fixed dev-only key.
+process.env.OAUTH_ISSUER = 'http://localhost:8888';
 delete process.env.JWE_SECRET;
 
 test('inferApplicationType: loopback and custom-scheme redirects are native', () => {

--- a/netlify/functions/mcp-server/logger.ts
+++ b/netlify/functions/mcp-server/logger.ts
@@ -137,11 +137,11 @@ export function getRequestId(
   }
 }
 
-export const MAX_LOGGED_FIELD_LENGTH = 200;
+const MAX_LOGGED_FIELD_LENGTH = 200;
 
 /** Bound a client-supplied string before it lands on a log line. */
-export function truncateForLog(value: unknown, max = MAX_LOGGED_FIELD_LENGTH): string | undefined {
-  return typeof value === 'string' ? value.slice(0, max) : undefined;
+export function truncateForLog(value: unknown): string | undefined {
+  return typeof value === 'string' ? value.slice(0, MAX_LOGGED_FIELD_LENGTH) : undefined;
 }
 
 function serializeError(err: unknown): unknown {

--- a/netlify/functions/mcp-server/logger.ts
+++ b/netlify/functions/mcp-server/logger.ts
@@ -137,6 +137,13 @@ export function getRequestId(
   }
 }
 
+export const MAX_LOGGED_FIELD_LENGTH = 200;
+
+/** Bound a client-supplied string before it lands on a log line. */
+export function truncateForLog(value: unknown, max = MAX_LOGGED_FIELD_LENGTH): string | undefined {
+  return typeof value === 'string' ? value.slice(0, max) : undefined;
+}
+
 function serializeError(err: unknown): unknown {
   if (err instanceof Error) {
     return { name: err.name, message: err.message, stack: err.stack };

--- a/netlify/functions/mcp-server/oauth-server.test.ts
+++ b/netlify/functions/mcp-server/oauth-server.test.ts
@@ -6,7 +6,7 @@ process.env.OAUTH_ISSUER = 'https://mcp.netlify.example.com';
 process.env.NTL_AUTH_CLIENT_ID = process.env.NTL_AUTH_CLIENT_ID || 'test-ntl-client';
 // A non-localhost issuer requires a real JWE_SECRET (see utils.ts) for
 // registration to mint a stateless client_id.
-process.env.JWE_SECRET = process.env.JWE_SECRET || 'a'.repeat(32);
+process.env.JWE_SECRET = 'a'.repeat(32);
 
 const { handler }: any = await import('../oauth-server.ts');
 

--- a/netlify/functions/mcp-server/oauth-server.test.ts
+++ b/netlify/functions/mcp-server/oauth-server.test.ts
@@ -4,6 +4,9 @@ import assert from 'node:assert/strict';
 // Deployed-style issuer so absolute URLs and identity lookups have a stable base.
 process.env.OAUTH_ISSUER = 'https://mcp.netlify.example.com';
 process.env.NTL_AUTH_CLIENT_ID = process.env.NTL_AUTH_CLIENT_ID || 'test-ntl-client';
+// A non-localhost issuer requires a real JWE_SECRET (see utils.ts) for
+// registration to mint a stateless client_id.
+process.env.JWE_SECRET = process.env.JWE_SECRET || 'a'.repeat(32);
 
 const { handler }: any = await import('../oauth-server.ts');
 
@@ -112,4 +115,40 @@ test('GET on the registration endpoint (management, unsupported) is 404', async 
   // Registration is POST-only; RFC 7592 management is not supported.
   const r = await call('GET', '/oauth-server/reg');
   assert.equal(r.status, 404);
+});
+
+test('register: request-context userAgent is bounded on the always-on log line', async () => {
+  const event = mkEvent(
+    'POST',
+    '/oauth-server/register',
+    JSON.stringify({ redirect_uris: ['http://127.0.0.1:1234/cb'], client_name: 'Claude Code' }),
+  );
+  event.headers['user-agent'] = 'x'.repeat(5000);
+
+  const lines: string[] = [];
+  const origLog = console.log;
+  console.log = (line: string) => {
+    lines.push(line);
+  };
+  let r: any;
+  try {
+    r = await handler(event, {} as any, () => {});
+  } finally {
+    console.log = origLog;
+  }
+
+  const parsed = lines
+    .map((line) => {
+      try {
+        return JSON.parse(line);
+      } catch {
+        return undefined;
+      }
+    })
+    .find((entry) => entry?.message === 'register: issued stateless client_id');
+
+  assert.equal(r.statusCode, 201);
+  assert.ok(parsed);
+  assert.equal(parsed.userAgent.length, 200);
+  assert.equal(parsed.client_name, 'Claude Code');
 });

--- a/netlify/functions/mcp-server/oauth-server.test.ts
+++ b/netlify/functions/mcp-server/oauth-server.test.ts
@@ -117,14 +117,7 @@ test('GET on the registration endpoint (management, unsupported) is 404', async 
   assert.equal(r.status, 404);
 });
 
-test('register: request-context userAgent is bounded on the always-on log line', async () => {
-  const event = mkEvent(
-    'POST',
-    '/oauth-server/register',
-    JSON.stringify({ redirect_uris: ['http://127.0.0.1:1234/cb'], client_name: 'Claude Code' }),
-  );
-  event.headers['user-agent'] = 'x'.repeat(5000);
-
+async function callCapturingRegisterLog(event: any): Promise<{ r: any; parsed: any }> {
   const lines: string[] = [];
   const origLog = console.log;
   console.log = (line: string) => {
@@ -147,8 +140,35 @@ test('register: request-context userAgent is bounded on the always-on log line',
     })
     .find((entry) => entry?.message === 'register: issued stateless client_id');
 
+  return { r, parsed };
+}
+
+test('register: request-context userAgent is bounded on the always-on log line', async () => {
+  const event = mkEvent(
+    'POST',
+    '/oauth-server/register',
+    JSON.stringify({ redirect_uris: ['http://127.0.0.1:1234/cb'], client_name: 'Claude Code' }),
+  );
+  event.headers['user-agent'] = 'x'.repeat(5000);
+
+  const { r, parsed } = await callCapturingRegisterLog(event);
+
   assert.equal(r.statusCode, 201);
   assert.ok(parsed);
   assert.equal(parsed.userAgent.length, 200);
   assert.equal(parsed.client_name, 'Claude Code');
+});
+
+test('register: request-context path is bounded on the always-on log line', async () => {
+  const event = mkEvent(
+    'POST',
+    '/oauth-server/' + 'x'.repeat(5000) + '/register',
+    JSON.stringify({ redirect_uris: ['http://127.0.0.1:1234/cb'], client_name: 'Claude Code' }),
+  );
+
+  const { r, parsed } = await callCapturingRegisterLog(event);
+
+  assert.equal(r.statusCode, 201);
+  assert.ok(parsed);
+  assert.equal(parsed.path.length, 200);
 });

--- a/netlify/functions/mcp-server/proxy.test.ts
+++ b/netlify/functions/mcp-server/proxy.test.ts
@@ -3,8 +3,9 @@ import assert from 'node:assert/strict';
 import { handleProxy } from '../../edge-functions/proxy.ts';
 import { createJWE } from './utils.ts';
 
-// createJWE/decryptJWE round-trip on the localhost dev key when JWE_SECRET and
-// OAUTH_ISSUER are unset (the test environment), so no secret setup is needed.
+// Pin the dev-key path regardless of ambient env: a localhost issuer with no
+// JWE_SECRET makes createJWE/decryptJWE use the fixed dev-only key.
+process.env.OAUTH_ISSUER = 'http://localhost:8888';
 delete process.env.JWE_SECRET;
 
 async function tokenFor(apisAllowed: Array<{ path: string; method: string }>): Promise<string> {

--- a/netlify/functions/mcp-server/proxy.test.ts
+++ b/netlify/functions/mcp-server/proxy.test.ts
@@ -5,6 +5,8 @@ import { createJWE } from './utils.ts';
 
 // createJWE/decryptJWE round-trip on the localhost dev key when JWE_SECRET and
 // OAUTH_ISSUER are unset (the test environment), so no secret setup is needed.
+delete process.env.JWE_SECRET;
+
 async function tokenFor(apisAllowed: Array<{ path: string; method: string }>): Promise<string> {
   return createJWE({ accessToken: 'nfp_test_token', apisAllowed }, '1h');
 }

--- a/netlify/functions/mcp.ts
+++ b/netlify/functions/mcp.ts
@@ -41,7 +41,7 @@ export default async (req: Request, context: Context) => {
       requestId: getRequestId(req.headers),
       deployId: getDeployId(context),
       httpMethod: req.method,
-      path: url.pathname,
+      path: truncateForLog(url.pathname),
       userAgent: truncateForLog(req.headers.get('user-agent')),
       mcpProtocolVersion: req.headers.get('mcp-protocol-version') ?? undefined,
     },

--- a/netlify/functions/mcp.ts
+++ b/netlify/functions/mcp.ts
@@ -13,7 +13,7 @@ import { registerClaudeDesignImportTool } from "../../src/tools/design-import/im
 import { userIsAuthenticated, getTokenIdentity } from "../../src/utils/api-networking.ts";
 import { isClaudeMCPClient } from "../../src/utils/client-detection.ts";
 import { maskToken, paramsSummary } from "./mcp-server/logging.ts";
-import { log, withLogContext, addLogContext, getRequestId, initLogger, getDeployId } from "./mcp-server/logger.ts";
+import { log, withLogContext, addLogContext, getRequestId, initLogger, getDeployId, truncateForLog } from "./mcp-server/logger.ts";
 import { withRequestSignals, getAuthChallenge } from "./mcp-server/request-signals.ts";
 import { systemLogForwarder } from "./mcp-server/system-log-forwarder.ts";
 import { installProcessGuards } from "./mcp-server/process-guards.ts";
@@ -42,7 +42,7 @@ export default async (req: Request, context: Context) => {
       deployId: getDeployId(context),
       httpMethod: req.method,
       path: url.pathname,
-      userAgent: req.headers.get('user-agent') ?? undefined,
+      userAgent: truncateForLog(req.headers.get('user-agent')),
       mcpProtocolVersion: req.headers.get('mcp-protocol-version') ?? undefined,
     },
     // Open a request-signals scope around the whole request so tool/API code can

--- a/netlify/functions/oauth-server.ts
+++ b/netlify/functions/oauth-server.ts
@@ -4,7 +4,7 @@ import { buildAuthServerMetadata, buildProtectedResourceMetadata } from "./mcp-s
 import { SUPPORTED_SCOPES, OAUTH_ROUTES } from "./mcp-server/oauth-config.ts";
 import { addCommonHeadersToHandlerResp, headersToHeadersObject, getParsedUrl } from "./mcp-server/utils.ts";
 import { safeBodySummary } from "./mcp-server/logging.ts";
-import { log, withLogContext, getRequestId, initLogger, getDeployId } from "./mcp-server/logger.ts";
+import { log, withLogContext, getRequestId, initLogger, getDeployId, truncateForLog } from "./mcp-server/logger.ts";
 import { systemLogForwarder } from "./mcp-server/system-log-forwarder.ts";
 import { installProcessGuards } from "./mcp-server/process-guards.ts";
 
@@ -123,7 +123,7 @@ export const handler: Handler = async (req, context) => {
       deployId: getDeployId(req.headers as Record<string, string | undefined>),
       httpMethod: req.httpMethod,
       path: req.path,
-      userAgent: (req.headers as Record<string, string | undefined>)['user-agent'],
+      userAgent: truncateForLog((req.headers as Record<string, string | undefined>)['user-agent']),
     },
     async () => {
       const resp = await oAuthHandler(req, context);

--- a/netlify/functions/oauth-server.ts
+++ b/netlify/functions/oauth-server.ts
@@ -105,7 +105,7 @@ const oAuthHandler: Handler = async (req) => {
 
   // No other OAuth endpoints exist on this server. Return a clean OAuth-style
   // error rather than letting the request fall through to a generic 404 page.
-  log.warn('oauth: unknown endpoint', { pathname, method: req.httpMethod });
+  log.warn('oauth: unknown endpoint', { pathname: truncateForLog(pathname), method: req.httpMethod });
   return jsonResponse(404, {
     error: 'invalid_request',
     error_description: `No such endpoint: ${pathname}`,
@@ -122,7 +122,7 @@ export const handler: Handler = async (req, context) => {
       requestId: getRequestId(req.headers as Record<string, string | undefined>),
       deployId: getDeployId(req.headers as Record<string, string | undefined>),
       httpMethod: req.httpMethod,
-      path: req.path,
+      path: truncateForLog(req.path),
       userAgent: truncateForLog((req.headers as Record<string, string | undefined>)['user-agent']),
     },
     async () => {

--- a/netlify/functions/oauth-server.ts
+++ b/netlify/functions/oauth-server.ts
@@ -105,7 +105,7 @@ const oAuthHandler: Handler = async (req) => {
 
   // No other OAuth endpoints exist on this server. Return a clean OAuth-style
   // error rather than letting the request fall through to a generic 404 page.
-  log.warn('oauth: unknown endpoint', { pathname: truncateForLog(pathname), method: req.httpMethod });
+  log.warn('oauth: unknown endpoint');
   return jsonResponse(404, {
     error: 'invalid_request',
     error_description: `No such endpoint: ${pathname}`,


### PR DESCRIPTION
## The short version

When an AI tool connects to our hosted MCP server for the first time, it registers and tells us its name — "Claude Code," "Cursor," and so on. We weren't writing that name down anywhere we could search. After this, it shows up in our logs, so we can count which tools are actually connecting. The name is whatever the tool says it is, so treat the counts as a strong hint, not proof.

## What was going on

The `register: issued stateless client_id` line only logged at debug level, and it didn't include `client_name`. So the one moment a client tells us who it is went nowhere. This is the spike for AX-150's attribution map: before we build anything on top of client names, I wanted to see which names real clients actually send.

## What changed

That registration line is now info level and includes `client_name`.

Everything on that line comes from the client, so I capped what gets logged. Name and scope stop at 200 characters. Redirect URIs log as hosts only, ten at most. That's for the log line only. The stored client_id and the 201 response are unchanged.

While I was in there, a new `truncateForLog` helper caps the `userAgent` and `path` request-context fields at every log entry point, so an oversized header or path can't bloat a log record. And the OAuth completion line logs the redirect host instead of the full URI.

Tests cover each cap through the real handler. The dev-key test files now pin their environment, so they pass on any machine.

## Checking it

Sean Roberts approved it. Once it deploys, `register: issued stateless client_id` should show up at info level in Humio with a `client_name` field.

Not in this PR, on purpose: EX-3083 (rate-limit registration, exact-path routing) and EX-3084 (cap the remaining always-on log fields).

Closes EX-3039
https://linear.app/netlify/issue/EX-3039/remote-mcp-log-oauth-client-name-at-registration-spike-for-ax-150
